### PR TITLE
Feature/262 obligar login registro compra

### DIFF
--- a/src/components/globalComponents/login/authModal.js
+++ b/src/components/globalComponents/login/authModal.js
@@ -786,16 +786,43 @@ useEffect(() => {
                     </div>
                   </div>
                 </form>
-                <button
-                  className="btn-link mt-2"
-                  onClick={() => {
-                    setForgotPassword(true);
-                    setMessage("");
-                    setError(null);
-                  }}
-                >
-                  ¿Has olvidado tú contraseña?
-                </button>
+                <div className="auth-links">
+                  <button
+                    className="btn-link mt-2"
+                    onClick={() => {
+                      setForgotPassword(true);
+                      setMessage("");
+                      setError(null);
+                    }}
+                  >
+                    ¿Has olvidado tu contraseña?
+                  </button>
+                  
+                  <button
+                    className="btn-link mt-2 register-link"
+                    onClick={() => {
+                      setModalType("signup");
+                      setError(null);
+                      setMessage("");
+                      setFieldErrors({});
+                      setForgotPassword(false);
+                      setEmail("");
+                      setPassword("");
+                      setRepeatPassword("");
+                      setFirstName("");
+                      setLastName("");
+                      setUsername("");
+                      setPhone("");
+                      setCompany("");
+                      setJob("");
+                      setSelectedComunidad("");
+                      setSelectedProvincia("");
+                      setSelectedMunicipio("");
+                    }}
+                  >
+                    ¿No tienes cuenta? <strong>Regístrate aquí</strong>
+                  </button>
+                </div>
               </>
             ) : null}
 

--- a/src/components/globalComponents/login/styles/authModal.scss
+++ b/src/components/globalComponents/login/styles/authModal.scss
@@ -637,3 +637,46 @@ select:disabled {
     color: #000000 !important;
   }
 }
+
+.auth-links {
+  display: flex;
+  flex-direction: row;
+  justify-content: center ;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  align-items: center;
+  background-color: transparent;
+  *{
+    background-color: transparent;
+  }
+  
+  .btn-link {
+    background: none;
+    border: none;
+    color: #666;
+    cursor: pointer;
+    font-size: 0.8rem;
+    padding: 0.5rem;
+    transition: color 0.2s;
+    
+    &:hover {
+      color: #333;
+      text-decoration: underline;
+    }
+    
+    &.register-link {
+      color: #007bff;
+      font-size: 0.8rem;
+      text-decoration: none;
+      
+      strong {
+        font-weight: 600;
+      }
+      
+      &:hover {
+        color: #0056b3;
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/src/components/globalComponents/socialIcons/socialIcons.js
+++ b/src/components/globalComponents/socialIcons/socialIcons.js
@@ -1,21 +1,22 @@
 
 import "./socialIcons.scss"
-import { FaFacebookSquare, FaLinkedin, FaInstagram } from "react-icons/fa";
+import { FaLinkedin, FaInstagram } from "react-icons/fa";
+import { RiYoutubeLine } from "react-icons/ri";
 import { FaSquareXTwitter } from "react-icons/fa6";
 
 const SocialIcons = () => {
   return (
     <div className="d-flex justify-content-center p-4 social-icons-container">
-      <a href="https://www.facebook.com" target="_blank" rel="noopener noreferrer" className="social-icon">
-        <FaFacebookSquare  />
+      <a href="https://www.youtube.com/@olawee_app/videos" target="_blank" rel="noopener noreferrer" className="social-icon">
+      <RiYoutubeLine />
       </a>
-      <a href="https://www.linkedin.com" target="_blank" rel="noopener noreferrer" className="social-icon">
+      <a href="https://www.linkedin.com/company/olawee/posts/?feedView=all" target="_blank" rel="noopener noreferrer" className="social-icon">
         <FaLinkedin />
       </a>
-      <a href="https://www.instagram.com" target="_blank" rel="noopener noreferrer" className="social-icon">
+      <a href="https://www.instagram.com/olawee_app/" target="_blank" rel="noopener noreferrer" className="social-icon">
         <FaInstagram />
       </a>
-      <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" className="social-icon">
+      <a href="https://x.com/OLAWEE_app/status/1982755081255882817" target="_blank" rel="noopener noreferrer" className="social-icon">
         <FaSquareXTwitter />
       </a>
     </div>

--- a/src/context/authProviderContext.js
+++ b/src/context/authProviderContext.js
@@ -1,6 +1,7 @@
 
 // // src/context/authProviderContext.js
 // import { createContext, useCallback, useContext, useEffect, useState } from "react";
+// import { useNavigate } from 'react-router-dom';
 // import {
 //   loginUser,
 //   forceLoginUser,
@@ -17,14 +18,16 @@
 
 // export const AuthProvider = ({ children }) => {
 //   const [user, setUser] = useState(null);
-//   const [loading, setLoading] = useState(true);
+//   const [loading, setLoading] = useState(true); // 🔥 CRÍTICO: Empieza en true
 //   const [selectedProduct, setSelectedProduct] = useState(null);
+//   const [isInitialized, setIsInitialized] = useState(false); // 🔥 NUEVO: Para tracking
+
+//   const navigate = useNavigate();
 
 //   // ============================================
 //   // FUNCIONES DE PERSISTENCIA DE TOKEN (MEMOIZADAS)
 //   // ============================================
 
-//   // ✅ getCurrentOrigin - Memoizado
 //   const getCurrentOrigin = useCallback(() => {
 //     const hostname = window.location.hostname;
     
@@ -46,7 +49,6 @@
 //     return detectedOrigin;
 //   }, []);
 
-//   // ✅ generateWindowId - NUEVO: ID único por ventana/pestaña
 //   const generateWindowId = useCallback(() => {
 //     let windowId = sessionStorage.getItem('window_session_id');
 //     if (!windowId) {
@@ -57,11 +59,9 @@
 //     return windowId;
 //   }, []);
 
-//   // ✅ saveAuthToken - MODIFICADO para priorizar sessionStorage + window_id
 //   const saveAuthToken = useCallback((token, sessionToken, origin, windowId, remember = true) => {
 //     const currentOrigin = origin || getCurrentOrigin();
 
-//     // 🔑 SIEMPRE guardamos en sessionStorage (única por pestaña)
 //     sessionStorage.setItem(`jwt_token_${currentOrigin}`, token);
 //     sessionStorage.setItem(`user_data`, JSON.stringify({
 //       token,
@@ -75,18 +75,12 @@
 //       sessionStorage.setItem(`session_token_${currentOrigin}`, sessionToken);
 //     }
 
-//     // ⚠️ CAMBIO IMPORTANTE: Ya NO guardamos en localStorage automáticamente
-//     // Para evitar que múltiples ventanas compartan la sesión
-//     if (remember) {
-//       console.log(`ℹ️ "Recordar sesión" habilitado, pero NO se guarda en localStorage para evitar múltiples ventanas`);
-//     }
+//     console.log(`✅ Token guardado en sessionStorage (origen: ${currentOrigin}, windowId: ${windowId})`);
 //   }, [getCurrentOrigin]);
 
-//   // ✅ getAuthToken - MODIFICADO para NO recuperar de localStorage
 //   const getAuthToken = useCallback(() => {
 //     const currentOrigin = getCurrentOrigin();
 
-//     // 🎯 SOLO lee de sessionStorage (única por pestaña)
 //     let token = sessionStorage.getItem(`jwt_token_${currentOrigin}`);
 //     let sessionToken = sessionStorage.getItem(`session_token_${currentOrigin}`);
 
@@ -95,28 +89,22 @@
 //       return { token, sessionToken, origin: currentOrigin };
 //     }
 
-//     // ⚠️ YA NO recuperamos de localStorage para evitar múltiples ventanas
 //     console.log(`ℹ️ No hay sesión activa en esta ventana`);
 //     return { token: null, sessionToken: null, origin: currentOrigin };
 //   }, [getCurrentOrigin]);
 
-//   // ✅ clearAuthTokens - MODIFICADO
 //   const clearAuthTokens = useCallback(() => {
 //     const currentOrigin = getCurrentOrigin();
 
-//     // Limpiar sessionStorage de ESTA pestaña
 //     sessionStorage.removeItem(`jwt_token_${currentOrigin}`);
 //     sessionStorage.removeItem(`session_token_${currentOrigin}`);
 //     sessionStorage.removeItem("user_data");
 //     sessionStorage.removeItem("window_session_id");
     
-//     // NO limpiar localStorage porque ya no lo usamos para sesiones
 //     console.log(`🧹 Tokens y window_id limpiados para origen: ${currentOrigin}`);
 //   }, [getCurrentOrigin]);
 
-//   // ✅ saveUserData - NUEVO: Guarda datos del usuario
 //   const saveUserData = useCallback((userData) => {
-//     // Guardar en sessionStorage (único por pestaña)
 //     sessionStorage.setItem("user_data", JSON.stringify(userData));
 //     sessionStorage.setItem("user_email", userData.email);
 //     sessionStorage.setItem("login_timestamp", Date.now().toString());
@@ -124,16 +112,20 @@
 //     console.log(`💾 Datos de usuario guardados en sessionStorage`);
 //   }, []);
 
-//   // ✅ getUserData - MODIFICADO: Solo lee de sessionStorage
 //   const getUserData = useCallback(() => {
-//     // Solo leer de sessionStorage
 //     const sessionUserData = sessionStorage.getItem("user_data");
 //     if (sessionUserData) {
-//       console.log(`✅ Datos de usuario encontrados en sessionStorage`);
-//       return JSON.parse(sessionUserData);
+//       try {
+//         const parsed = JSON.parse(sessionUserData);
+//         console.log(`✅ Datos de usuario encontrados en sessionStorage:`, parsed.email);
+//         return parsed;
+//       } catch (e) {
+//         console.error('❌ Error parseando user_data:', e);
+//         sessionStorage.removeItem("user_data");
+//         return null;
+//       }
 //     }
 
-//     // ⚠️ YA NO recuperamos de localStorage
 //     console.log(`ℹ️ No hay datos de usuario en esta ventana`);
 //     return null;
 //   }, []);
@@ -221,43 +213,134 @@
 //   }, [clearAuthTokens]);
 
 //   // ============================================
-//   // INICIALIZACIÓN - MODIFICADO
+//   // 🔥 INICIALIZACIÓN - MEJORADO
 //   // ============================================
 
 //   useEffect(() => {
+//     // 🔥 Evitar ejecuciones múltiples
+//     if (isInitialized) {
+//       console.log('ℹ️ Ya inicializado, saltando...');
+//       return;
+//     }
+
 //     const initAuth = async () => {
-//       // 🪟 Generar window_id al iniciar
-//       generateWindowId();
-      
-//       // 🎯 Obtener datos del usuario desde sessionStorage (NO localStorage)
-//       const storedUser = getUserData();
-//       const { token, sessionToken } = getAuthToken();
+//       console.log('🚀 ========== INICIANDO AUTENTICACIÓN ==========');
+//       console.log('🔍 Estado inicial - loading:', loading, 'user:', user?.email);
 
-//       if (storedUser && token) {
-//         try {
-//           setUser(storedUser);
+//       try {
+//         // 1. Generar window_id
+//         const windowId = generateWindowId();
+//         console.log('🪟 Window ID:', windowId);
+        
+//         // 2. Obtener token desde sessionStorage
+//         const { token, sessionToken } = getAuthToken();
+//         console.log('🔑 Token encontrado:', token ? 'SÍ' : 'NO');
+
+//         // 3. Si no hay token, terminar inicialización
+//         if (!token) {
+//           console.log('ℹ️ No hay token, inicialización completa (sin usuario)');
+//           setIsInitialized(true);
 //           setLoading(false);
-
-//           // Verificar en segundo plano
-//           setTimeout(() => {
-//             silentTokenVerification(token, sessionToken).catch(() => {
-//               console.warn("⚠️ Verificación de token silenciosa falló");
-//             });
-//           }, 1000);
 //           return;
-//         } catch (error) {
-//           console.error("❌ Error al procesar datos del usuario:", error);
 //         }
+
+//         // 4. Obtener datos del usuario desde sessionStorage
+//         const storedUser = getUserData();
+//         console.log('👤 Usuario guardado:', storedUser ? storedUser.email : 'NO');
+
+//         // 5. Si hay token pero no hay datos de usuario, limpiar
+//         if (!storedUser) {
+//           console.warn('⚠️ Token existe pero no hay datos de usuario, limpiando...');
+//           clearAuthTokens();
+//           setIsInitialized(true);
+//           setLoading(false);
+//           return;
+//         }
+
+//         // 6. Verificar que el token no esté expirado (básico)
+//         try {
+//           const payload = token.split(".")[1];
+//           const decoded = JSON.parse(atob(payload));
+//           const now = Date.now() / 1000;
+          
+//           if (decoded.exp && decoded.exp < now) {
+//             console.warn('⚠️ Token expirado, limpiando...');
+//             clearAuthTokens();
+//             sessionStorage.removeItem("user_data");
+//             setIsInitialized(true);
+//             setLoading(false);
+//             return;
+//           }
+//           console.log('✅ Token NO expirado, válido hasta:', new Date(decoded.exp * 1000).toLocaleString());
+//         } catch (decodeError) {
+//           console.error('❌ Error decodificando token:', decodeError);
+//           clearAuthTokens();
+//           sessionStorage.removeItem("user_data");
+//           setIsInitialized(true);
+//           setLoading(false);
+//           return;
+//         }
+
+//         // 7. Restaurar usuario
+//         console.log('✅ Restaurando sesión del usuario:', storedUser.email);
+//         setUser(storedUser);
+//         setIsInitialized(true);
+//         setLoading(false);
+
+//         // 8. Verificar en segundo plano (sin bloquear)
+//         setTimeout(() => {
+//           console.log('🔄 Iniciando verificación silenciosa...');
+//           silentTokenVerification(token, sessionToken).catch((err) => {
+//             console.warn("⚠️ Verificación de token silenciosa falló:", err);
+//           });
+//         }, 2000); // Esperar 2 segundos después de cargar
+
+//       } catch (error) {
+//         console.error("❌ Error durante inicialización:", error);
+//         clearAuthTokens();
+//         sessionStorage.removeItem("user_data");
+//         setUser(null);
+//         setIsInitialized(true);
+//         setLoading(false);
 //       }
 
-//       setLoading(false);
+//       console.log('✅ ========== FIN INICIALIZACIÓN ==========');
 //     };
 
 //     initAuth();
-//   }, [getAuthToken, getUserData, generateWindowId, silentTokenVerification]);
+//   }, [clearAuthTokens, generateWindowId, getAuthToken, getUserData, isInitialized, loading, silentTokenVerification, user?.email]); // 🔥 SOLO ejecutar UNA vez al montar
+
+//   // 🔥 LISTENER para forzar logout desde otras pestañas
+//   useEffect(() => {
+//     const handleBroadcast = (event) => {
+//       if (event.data.type === 'FORCE_LOGOUT') {
+//         const myWindowId = sessionStorage.getItem('window_session_id');
+        
+//         // Si el mensaje NO es de esta ventana, hacer logout
+//         if (event.data.windowId !== myWindowId) {
+//           console.warn('⚠️ Force logout detectado desde otra ventana');
+//           clearAuthTokens();
+//           sessionStorage.removeItem("user_data");
+//           setUser(null);
+//         }
+//       }
+//     };
+
+//     try {
+//       const channel = new BroadcastChannel('olawee_session_channel');
+//       channel.addEventListener('message', handleBroadcast);
+      
+//       return () => {
+//         channel.removeEventListener('message', handleBroadcast);
+//         channel.close();
+//       };
+//     } catch (e) {
+//       console.warn('⚠️ BroadcastChannel no soportado');
+//     }
+//   }, [clearAuthTokens]);
 
 //   // ============================================
-//   // LOGIN - MODIFICADO
+//   // LOGIN
 //   // ============================================
 
 //   const login = useCallback(async (emailOrUsername, password, rememberMe = true) => {
@@ -274,17 +357,15 @@
 
 //       console.log("Intentando iniciar sesión con:", { username: cleanEmailOrUsername });
 
-//       // 🪟 NUEVO: Generar window_id para esta ventana
 //       const windowId = generateWindowId();
 
-//       // Verificar caché de ESTA pestaña (sessionStorage)
+//       // Verificar caché de ESTA pestaña
 //       const cachedUserData = sessionStorage.getItem("user_data");
 //       const cachedUserEmail = sessionStorage.getItem("user_email");
 //       const cachedTimestamp = sessionStorage.getItem("login_timestamp");
 //       const { token: cachedToken, sessionToken: cachedSessionToken } = getAuthToken();
 //       const now = Date.now();
 
-//       // Si hay caché reciente en esta pestaña
 //       if (cachedUserData && cachedUserEmail === cleanEmailOrUsername && cachedTimestamp && cachedToken) {
 //         if (now - parseInt(cachedTimestamp) < 2 * 60 * 60 * 1000) {
 //           try {
@@ -303,16 +384,13 @@
 //         }
 //       }
 
-//       // Diagnóstico de red
 //       const networkCheck = await checkNetworkQuality();
 //       console.log(`🔄 Calidad de conexión al servidor: ${networkCheck.quality}`);
 
-//       // Intentar login (ahora incluye windowId)
 //       console.time("⏱ LOGIN API");
 //       const result = await loginUser(cleanEmailOrUsername, cleanPassword, windowId);
 //       console.timeEnd("⏱ LOGIN API");
 
-//       // Verificar conflicto de sesión
 //       if (result.conflict) {
 //         console.warn("⚠️ Conflicto de sesión detectado");
 //         return {
@@ -323,13 +401,10 @@
 //         };
 //       }
 
-//       // Login exitoso
 //       const { token, sessionToken, origin, user: profileData } = result;
 
-//       // Guardar tokens (ahora incluye windowId)
 //       saveAuthToken(token, sessionToken, origin, windowId, rememberMe);
 
-//       // Construir objeto de usuario
 //       const fullUser = {
 //         id: profileData.id,
 //         username: profileData.username || profileData.email,
@@ -349,11 +424,7 @@
 //         meta: {},
 //       };
 
-//       // 💾 Guardar datos del usuario en sessionStorage SOLAMENTE
 //       saveUserData(fullUser);
-      
-//       // ⚠️ YA NO guardamos en localStorage para evitar múltiples ventanas
-
 //       sessionStorage.setItem("token_last_verified", now.toString());
 //       setUser(fullUser);
 
@@ -363,7 +434,6 @@
 //     } catch (err) {
 //       console.error("❌ Error durante el login:", err);
 
-//       // Fallback a caché en caso de error de red
 //       if (
 //         err.message === "Timeout" ||
 //         err.name === "AbortError" ||
@@ -408,7 +478,7 @@
 //   }, [getAuthToken, saveAuthToken, saveUserData, checkNetworkQuality, silentTokenVerification, generateWindowId]);
 
 //   // ============================================
-//   // FORCE LOGIN - MODIFICADO
+//   // FORCE LOGIN
 //   // ============================================
 
 //   const forceLogin = useCallback(async (emailOrUsername, password, rememberMe = true) => {
@@ -425,7 +495,6 @@
 
 //       console.log("🔄 Forzando inicio de sesión (cerrando otras sesiones)");
 
-//       // 🪟 NUEVO: Generar window_id
 //       const windowId = generateWindowId();
 
 //       const result = await forceLoginUser(cleanEmailOrUsername, cleanPassword, windowId);
@@ -454,14 +523,11 @@
 
 //       const now = Date.now();
 //       saveUserData(fullUser);
-      
-//       // ⚠️ YA NO guardamos en localStorage
 //       sessionStorage.setItem("token_last_verified", now.toString());
 //       setUser(fullUser);
 
 //       console.log("✅ Force login exitoso:", fullUser);
 
-//       // 📢 NUEVO: Notificar a otras ventanas que se hizo force login
 //       try {
 //         const channel = new BroadcastChannel('olawee_session_channel');
 //         channel.postMessage({
@@ -492,7 +558,7 @@
 //   }, [saveAuthToken, saveUserData, generateWindowId]);
 
 //   // ============================================
-//   // REGISTER - MODIFICADO
+//   // REGISTER
 //   // ============================================
 
 //   const register = useCallback(async (userData) => {
@@ -506,7 +572,6 @@
 
 //       const { token, sessionToken, origin, user: profileData } = result;
 
-//       // 🪟 NUEVO: Generar window_id
 //       const windowId = generateWindowId();
       
 //       saveAuthToken(token, sessionToken, origin, windowId, true);
@@ -532,8 +597,6 @@
 
 //       const now = Date.now();
 //       saveUserData(fullUser);
-      
-//       // ⚠️ YA NO guardamos en localStorage
 //       sessionStorage.setItem("token_last_verified", now.toString());
 
 //       setUser(fullUser);
@@ -556,24 +619,23 @@
 //   }, [saveAuthToken, saveUserData, generateWindowId]);
 
 //   // ============================================
-//   // LOGOUT - MODIFICADO
+//   // LOGOUT
 //   // ============================================
 
 //   const logout = useCallback(async () => {
 //     try {
 //       const { token } = getAuthToken();
-
+  
 //       if (token) {
 //         await logoutUser(token);
 //       }
-
+  
 //       clearAuthTokens();
 //       sessionStorage.removeItem("user_data");
 //       sessionStorage.removeItem("user_email");
 //       sessionStorage.removeItem("login_timestamp");
 //       sessionStorage.removeItem("token_last_verified");
       
-//       // Limpiar datos antiguos de localStorage si existen
 //       localStorage.removeItem("user_data");
 //       localStorage.removeItem("user_email");
 //       localStorage.removeItem("login_timestamp");
@@ -581,22 +643,49 @@
 //       localStorage.removeItem("user_data_timestamp");
 //       localStorage.removeItem("site_config_timestamp");
 //       localStorage.removeItem("user_preferences_timestamp");
-
+  
 //       setUser(null);
-
+  
 //       console.log("✅ Logout exitoso");
+  
+//       // 🔥 NUEVO: Redirección automática desde páginas sensibles
+//       const currentPath = window.location.pathname;
+//       const sensitiveRoutes = ['/checkout', '/order-confirmation', '/my-account'];
+      
+//       const isInSensitiveRoute = sensitiveRoutes.some(route => 
+//         currentPath.includes(route)
+//       );
+      
+//       if (isInSensitiveRoute) {
+//         console.log("🔄 Redirigiendo desde página protegida a home");
+//         navigate('/');
+//       }
+  
 //     } catch (err) {
 //       console.error("⚠️ Error en logout, limpiando localmente:", err.message);
-
+  
 //       clearAuthTokens();
 //       sessionStorage.removeItem("user_data");
 //       sessionStorage.removeItem("user_email");
 //       localStorage.removeItem("user_data");
 //       localStorage.removeItem("user_email");
-
+  
 //       setUser(null);
+  
+//       // 🔥 NUEVO: Redirección también en caso de error
+//       const currentPath = window.location.pathname;
+//       const sensitiveRoutes = ['/checkout', '/order-confirmation', '/my-account'];
+      
+//       const isInSensitiveRoute = sensitiveRoutes.some(route => 
+//         currentPath.includes(route)
+//       );
+      
+//       if (isInSensitiveRoute) {
+//         console.log("🔄 Redirigiendo desde página protegida a home (tras error)");
+//         navigate('/');
+//       }
 //     }
-//   }, [getAuthToken, clearAuthTokens]);
+//   }, [getAuthToken, clearAuthTokens, navigate]); // 🔥 Añadir navigate a dependencias
 
 //   // ============================================
 //   // PASSWORD RESET
@@ -711,18 +800,12 @@
     
 //     setUser(updatedUser);
 //     saveUserData(updatedUser);
-    
-//     // ⚠️ YA NO actualizamos localStorage
 //   }, [user, saveUserData]);
 
-//    // ============================================
+//   // ============================================
 //   // GESTIÓN DE PRODUCTO PARA CHECKOUT
 //   // ============================================
 
-//   /**
-//    * Selecciona un producto para llevar al checkout
-//    * @param {Object} product - Producto de WooCommerce
-//    */
 //   const selectProductForCheckout = useCallback((product) => {
 //     if (!product || !product.id) {
 //       console.warn('⚠️ Producto inválido:', product);
@@ -734,19 +817,12 @@
 //     console.log('✅ Producto seleccionado para checkout:', product.name);
 //   }, []);
 
-//   /**
-//    * Limpia el producto seleccionado
-//    */
 //   const clearSelectedProduct = useCallback(() => {
 //     setSelectedProduct(null);
 //     sessionStorage.removeItem('selected_product');
 //     console.log('🧹 Producto seleccionado limpiado');
 //   }, []);
 
-//   /**
-//    * Recupera el producto guardado (si existe)
-//    * Se llama automáticamente al iniciar la app
-//    */
 //   const restoreSelectedProduct = useCallback(() => {
 //     try {
 //       const savedProduct = sessionStorage.getItem('selected_product');
@@ -764,11 +840,8 @@
 //   }, []);
 
 //   useEffect(() => {
-//     // Restaurar producto seleccionado si existe
 //     restoreSelectedProduct();
 //   }, [restoreSelectedProduct]);
-
-
 
 //   return (
 //     <AuthContext.Provider
@@ -779,7 +852,7 @@
 //         forceLogin,
 //         register,
 //         logout,
-//         loading,
+//         loading, // 🔥 EXPORTAR loading
 //         isAuthenticated,
 //         revalidate,
 //         updateUser,
@@ -798,6 +871,13 @@
 // };
 
 // export const useAuth = () => useContext(AuthContext);
+
+
+
+
+
+
+
 
 
 
@@ -942,51 +1022,51 @@ export const AuthProvider = ({ children }) => {
   // VERIFICACIÓN DE CALIDAD DE RED
   // ============================================
 
-  const checkNetworkQuality = useCallback(async (baseUrl) => {
-    const startTime = performance.now();
-    let status = "unknown";
-    let pingTime = 0;
+  // const checkNetworkQuality = useCallback(async (baseUrl) => {
+  //   const startTime = performance.now();
+  //   let status = "unknown";
+  //   let pingTime = 0;
 
-    try {
-      const apiBase = baseUrl || "https://api.olawee.com";
-      const response = await fetch(`${apiBase}/wp-json`, {
-        method: "HEAD",
-        cache: "no-store",
-        credentials: "omit",
-      });
+  //   try {
+  //     const apiBase = baseUrl || "https://api.olawee.com";
+  //     const response = await fetch(`${apiBase}/wp-json`, {
+  //       method: "HEAD",
+  //       cache: "no-store",
+  //       credentials: "omit",
+  //     });
 
-      pingTime = performance.now() - startTime;
-      status = response.ok ? "available" : "error";
+  //     pingTime = performance.now() - startTime;
+  //     status = response.ok ? "available" : "error";
 
-      const networkQuality =
-        pingTime < 300
-          ? "excellent"
-          : pingTime < 1000
-          ? "good"
-          : pingTime < 3000
-          ? "fair"
-          : "poor";
+  //     const networkQuality =
+  //       pingTime < 300
+  //         ? "excellent"
+  //         : pingTime < 1000
+  //         ? "good"
+  //         : pingTime < 3000
+  //         ? "fair"
+  //         : "poor";
 
-      console.log(`📶 Calidad de red: ${networkQuality} (${Math.round(pingTime)}ms)`);
+  //     console.log(`📶 Calidad de red: ${networkQuality} (${Math.round(pingTime)}ms)`);
 
-      return {
-        status,
-        pingTime,
-        quality: networkQuality,
-        httpStatus: response.status,
-      };
-    } catch (err) {
-      pingTime = performance.now() - startTime;
-      console.error(`❌ Error de conexión: ${err.message}`);
+  //     return {
+  //       status,
+  //       pingTime,
+  //       quality: networkQuality,
+  //       httpStatus: response.status,
+  //     };
+  //   } catch (err) {
+  //     pingTime = performance.now() - startTime;
+  //     console.error(`❌ Error de conexión: ${err.message}`);
 
-      return {
-        status: "error",
-        pingTime,
-        quality: "unavailable",
-        error: err.message,
-      };
-    }
-  }, []);
+  //     return {
+  //       status: "error",
+  //       pingTime,
+  //       quality: "unavailable",
+  //       error: err.message,
+  //     };
+  //   }
+  // }, []);
 
   // ============================================
   // VERIFICACIÓN SILENCIOSA DE TOKEN
@@ -1019,6 +1099,66 @@ export const AuthProvider = ({ children }) => {
       return false;
     }
   }, [clearAuthTokens]);
+
+  // ============================================
+  // 🔥 GESTIÓN DE INTENCIÓN DE CHECKOUT (NUEVO)
+  // ============================================
+
+  /**
+   * Guardar intención de compra antes de login/registro
+   */
+  const saveCheckoutIntent = useCallback((product, additionalData = {}) => {
+    const checkoutIntent = {
+      product,
+      timestamp: Date.now(),
+      path: window.location.pathname,
+      ...additionalData
+    };
+    
+    sessionStorage.setItem('checkout_intent', JSON.stringify(checkoutIntent));
+    console.log('💾 Intención de checkout guardada:', product?.name || 'Sin nombre');
+  }, []);
+
+  /**
+   * Restaurar intención de compra después del login/registro
+   */
+  const restoreCheckoutIntent = useCallback(() => {
+    try {
+      const savedIntent = sessionStorage.getItem('checkout_intent');
+      if (savedIntent) {
+        const intent = JSON.parse(savedIntent);
+        console.log('♻️ Restaurando intención de checkout:', intent);
+        
+        // Verificar que la intención no sea muy antigua (30 minutos)
+        const thirtyMinutes = 30 * 60 * 1000;
+        if (Date.now() - intent.timestamp > thirtyMinutes) {
+          console.log('⏰ Intención de checkout expirada, limpiando...');
+          sessionStorage.removeItem('checkout_intent');
+          return null;
+        }
+        
+        // Restaurar el producto seleccionado
+        if (intent.product) {
+          setSelectedProduct(intent.product);
+          sessionStorage.setItem('selected_product', JSON.stringify(intent.product));
+        }
+        
+        return intent;
+      }
+    } catch (e) {
+      console.error('❌ Error al restaurar intención de checkout:', e);
+      sessionStorage.removeItem('checkout_intent');
+    }
+    return null;
+  }, []);
+
+  /**
+   * Limpiar intención de checkout
+   */
+  const clearCheckoutIntent = useCallback(() => {
+    sessionStorage.removeItem('checkout_intent');
+    console.log('🧹 Intención de checkout limpiada');
+  }, []);
 
   // ============================================
   // 🔥 INICIALIZACIÓN - MEJORADO
@@ -1065,217 +1205,85 @@ export const AuthProvider = ({ children }) => {
           return;
         }
 
-        // 6. Verificar que el token no esté expirado (básico)
-        try {
-          const payload = token.split(".")[1];
-          const decoded = JSON.parse(atob(payload));
-          const now = Date.now() / 1000;
-          
-          if (decoded.exp && decoded.exp < now) {
-            console.warn('⚠️ Token expirado, limpiando...');
-            clearAuthTokens();
-            sessionStorage.removeItem("user_data");
-            setIsInitialized(true);
-            setLoading(false);
-            return;
-          }
-          console.log('✅ Token NO expirado, válido hasta:', new Date(decoded.exp * 1000).toLocaleString());
-        } catch (decodeError) {
-          console.error('❌ Error decodificando token:', decodeError);
-          clearAuthTokens();
-          sessionStorage.removeItem("user_data");
-          setIsInitialized(true);
-          setLoading(false);
-          return;
-        }
-
-        // 7. Restaurar usuario
-        console.log('✅ Restaurando sesión del usuario:', storedUser.email);
+        // 6. Establecer usuario desde sessionStorage
+        console.log('✅ Restaurando sesión desde sessionStorage');
         setUser(storedUser);
-        setIsInitialized(true);
-        setLoading(false);
 
-        // 8. Verificar en segundo plano (sin bloquear)
-        setTimeout(() => {
-          console.log('🔄 Iniciando verificación silenciosa...');
-          silentTokenVerification(token, sessionToken).catch((err) => {
-            console.warn("⚠️ Verificación de token silenciosa falló:", err);
-          });
-        }, 2000); // Esperar 2 segundos después de cargar
+        // 7. Verificar token en segundo plano (no bloquea UI)
+        silentTokenVerification(token, sessionToken).then((isValid) => {
+          if (!isValid) {
+            console.warn('⚠️ Token expirado detectado en verificación silenciosa');
+          }
+        });
 
-      } catch (error) {
-        console.error("❌ Error durante inicialización:", error);
+      } catch (err) {
+        console.error('❌ Error en inicialización:', err);
         clearAuthTokens();
         sessionStorage.removeItem("user_data");
-        setUser(null);
+      } finally {
         setIsInitialized(true);
         setLoading(false);
+        console.log('✅ Inicialización completa');
       }
-
-      console.log('✅ ========== FIN INICIALIZACIÓN ==========');
     };
 
     initAuth();
-  }, [clearAuthTokens, generateWindowId, getAuthToken, getUserData, isInitialized, loading, silentTokenVerification, user?.email]); // 🔥 SOLO ejecutar UNA vez al montar
-
-  // 🔥 LISTENER para forzar logout desde otras pestañas
-  useEffect(() => {
-    const handleBroadcast = (event) => {
-      if (event.data.type === 'FORCE_LOGOUT') {
-        const myWindowId = sessionStorage.getItem('window_session_id');
-        
-        // Si el mensaje NO es de esta ventana, hacer logout
-        if (event.data.windowId !== myWindowId) {
-          console.warn('⚠️ Force logout detectado desde otra ventana');
-          clearAuthTokens();
-          sessionStorage.removeItem("user_data");
-          setUser(null);
-        }
-      }
-    };
-
-    try {
-      const channel = new BroadcastChannel('olawee_session_channel');
-      channel.addEventListener('message', handleBroadcast);
-      
-      return () => {
-        channel.removeEventListener('message', handleBroadcast);
-        channel.close();
-      };
-    } catch (e) {
-      console.warn('⚠️ BroadcastChannel no soportado');
-    }
-  }, [clearAuthTokens]);
+  }, [
+    isInitialized,
+    loading,
+    user?.email,
+    generateWindowId,
+    getAuthToken,
+    getUserData,
+    clearAuthTokens,
+    silentTokenVerification
+  ]);
 
   // ============================================
   // LOGIN
   // ============================================
 
-  const login = useCallback(async (emailOrUsername, password, rememberMe = true) => {
+  const login = useCallback(async (email, password, origin = 'web') => {
     try {
-      const cleanEmailOrUsername = emailOrUsername?.toString().trim();
-      const cleanPassword = password?.toString().trim();
-
-      if (!cleanEmailOrUsername || !cleanPassword) {
-        throw new AuthError(
-          "El correo electrónico/usuario y la contraseña son obligatorios",
-          "missing_fields"
-        );
-      }
-
-      console.log("Intentando iniciar sesión con:", { username: cleanEmailOrUsername });
-
       const windowId = generateWindowId();
+      const result = await loginUser(email, password, origin, windowId);
 
-      // Verificar caché de ESTA pestaña
-      const cachedUserData = sessionStorage.getItem("user_data");
-      const cachedUserEmail = sessionStorage.getItem("user_email");
-      const cachedTimestamp = sessionStorage.getItem("login_timestamp");
-      const { token: cachedToken, sessionToken: cachedSessionToken } = getAuthToken();
-      const now = Date.now();
-
-      if (cachedUserData && cachedUserEmail === cleanEmailOrUsername && cachedTimestamp && cachedToken) {
-        if (now - parseInt(cachedTimestamp) < 2 * 60 * 60 * 1000) {
-          try {
-            const userData = JSON.parse(cachedUserData);
-            console.log("✅ Login exitoso (desde caché de sessionStorage)");
-            setUser(userData);
-
-            setTimeout(() => {
-              silentTokenVerification(cachedToken, cachedSessionToken).catch(() => {});
-            }, 1000);
-
-            return userData;
-          } catch (cacheError) {
-            console.warn("⚠️ Error al usar caché:", cacheError.message);
-          }
-        }
+      if (result && result.conflict) {
+        return result;
       }
 
-      const networkCheck = await checkNetworkQuality();
-      console.log(`🔄 Calidad de conexión al servidor: ${networkCheck.quality}`);
+      if (result.token && result.user) {
+        saveAuthToken(result.token, result.sessionToken, origin, windowId);
+        saveUserData(result.user);
+        setUser(result.user);
 
-      console.time("⏱ LOGIN API");
-      const result = await loginUser(cleanEmailOrUsername, cleanPassword, windowId);
-      console.timeEnd("⏱ LOGIN API");
+        console.log(`✅ Login exitoso: ${result.user.email}`);
 
-      if (result.conflict) {
-        console.warn("⚠️ Conflicto de sesión detectado");
-        return {
-          conflict: true,
-          message: result.message,
-          origin: result.origin,
-          user: result.user,
-        };
-      }
-
-      const { token, sessionToken, origin, user: profileData } = result;
-
-      saveAuthToken(token, sessionToken, origin, windowId, rememberMe);
-
-      const fullUser = {
-        id: profileData.id,
-        username: profileData.username || profileData.email,
-        email: profileData.email,
-        displayName: profileData.name || 
-          `${profileData.first_name || ""} ${profileData.last_name || ""}`.trim(),
-        firstName: profileData.first_name || "",
-        lastName: profileData.last_name || "",
-        phone: profileData.phone || "",
-        company: profileData.empresa || "",
-        country: profileData.country || "",
-        state: profileData.state || "",
-        city: profileData.city || "",
-        job: profileData.job || "",
-        roles: profileData.roles || [],
-        avatarUrl: null,
-        meta: {},
-      };
-
-      saveUserData(fullUser);
-      sessionStorage.setItem("token_last_verified", now.toString());
-      setUser(fullUser);
-
-      console.log("✅ Login exitoso:", fullUser);
-
-      return fullUser;
-    } catch (err) {
-      console.error("❌ Error durante el login:", err);
-
-      if (
-        err.message === "Timeout" ||
-        err.name === "AbortError" ||
-        err.code === "ECONNABORTED" ||
-        err.message.includes("timeout") ||
-        err.message === "canceled" ||
-        err.code === "ERR_CANCELED" ||
-        err.message.includes("network")
-      ) {
-        const cachedUserData = sessionStorage.getItem("user_data");
-        const cachedUserEmail = sessionStorage.getItem("user_email");
-
-        if (cachedUserData && cachedUserEmail === emailOrUsername?.toString().trim()) {
-          try {
-            console.log("⚠️ Usando caché de sessionStorage como fallback");
-            const userData = JSON.parse(cachedUserData);
-            setUser({ ...userData, _offlineMode: true });
-            return {
-              ...userData,
-              _warning: "Usando datos guardados debido a problemas de conexión",
-            };
-          } catch (fallbackError) {
-            console.error("❌ También falló el uso de caché:", fallbackError);
-          }
+        // 🔥 NUEVO: Restaurar intención de checkout si existe
+        const checkoutIntent = restoreCheckoutIntent();
+        if (checkoutIntent) {
+          console.log('✅ Intención de checkout restaurada tras login');
         }
 
+        return result;
+      } else {
         throw new AuthError(
-          "La conexión con el servidor está tardando demasiado. Por favor, verifica tu conexión a internet o inténtalo más tarde.",
-          "network_timeout"
+          "No se recibieron credenciales válidas",
+          "invalid_response"
         );
       }
+    } catch (err) {
+      console.error("❌ Error en login:", err);
 
-      if (err.code) {
-        throw new AuthError(err.message, err.code);
+      if (err.code === "invalid_username" || err.code === "invalid_email") {
+        throw new AuthError("El email proporcionado no es válido", "invalid_email");
+      } else if (err.code === "incorrect_password") {
+        throw new AuthError("La contraseña es incorrecta", "invalid_credentials");
+      } else if (err.code === "network_error") {
+        throw new AuthError(
+          "Error de conexión. Por favor, verifica tu conexión a internet",
+          "network_error"
+        );
       }
 
       throw new AuthError(
@@ -1283,140 +1291,96 @@ export const AuthProvider = ({ children }) => {
         "unknown_error"
       );
     }
-  }, [getAuthToken, saveAuthToken, saveUserData, checkNetworkQuality, silentTokenVerification, generateWindowId]);
+  }, [generateWindowId, saveAuthToken, saveUserData, restoreCheckoutIntent]);
 
   // ============================================
   // FORCE LOGIN
   // ============================================
 
-  const forceLogin = useCallback(async (emailOrUsername, password, rememberMe = true) => {
+  const forceLogin = useCallback(async (email, password, origin = 'web') => {
     try {
-      const cleanEmailOrUsername = emailOrUsername?.toString().trim();
-      const cleanPassword = password?.toString().trim();
+      const windowId = generateWindowId();
+      const result = await forceLoginUser(email, password, origin, windowId);
 
-      if (!cleanEmailOrUsername || !cleanPassword) {
+      if (result.token && result.user) {
+        saveAuthToken(result.token, result.sessionToken, origin, windowId);
+        saveUserData(result.user);
+        setUser(result.user);
+
+        console.log(`✅ Force login exitoso: ${result.user.email}`);
+
+        // 🔥 NUEVO: Restaurar intención de checkout si existe
+        const checkoutIntent = restoreCheckoutIntent();
+        if (checkoutIntent) {
+          console.log('✅ Intención de checkout restaurada tras force login');
+        }
+
+        return result;
+      } else {
         throw new AuthError(
-          "El correo electrónico/usuario y la contraseña son obligatorios",
-          "missing_fields"
+          "No se recibieron credenciales válidas",
+          "invalid_response"
         );
       }
-
-      console.log("🔄 Forzando inicio de sesión (cerrando otras sesiones)");
-
-      const windowId = generateWindowId();
-
-      const result = await forceLoginUser(cleanEmailOrUsername, cleanPassword, windowId);
-      const { token, sessionToken, origin, user: profileData } = result;
-
-      saveAuthToken(token, sessionToken, origin, windowId, rememberMe);
-
-      const fullUser = {
-        id: profileData.id,
-        username: profileData.username || profileData.email,
-        email: profileData.email,
-        displayName: profileData.name || 
-          `${profileData.first_name || ""} ${profileData.last_name || ""}`.trim(),
-        firstName: profileData.first_name || "",
-        lastName: profileData.last_name || "",
-        phone: profileData.phone || "",
-        company: profileData.empresa || "",
-        country: profileData.country || "",
-        state: profileData.state || "",
-        city: profileData.city || "",
-        job: profileData.job || "",
-        roles: profileData.roles || [],
-        avatarUrl: null,
-        meta: {},
-      };
-
-      const now = Date.now();
-      saveUserData(fullUser);
-      sessionStorage.setItem("token_last_verified", now.toString());
-      setUser(fullUser);
-
-      console.log("✅ Force login exitoso:", fullUser);
-
-      try {
-        const channel = new BroadcastChannel('olawee_session_channel');
-        channel.postMessage({
-          type: 'FORCE_LOGOUT',
-          windowId: windowId,
-          origin: origin,
-          timestamp: now
-        });
-        channel.close();
-        console.log('📢 Notificación FORCE_LOGOUT enviada a otras ventanas');
-      } catch (broadcastError) {
-        console.warn('⚠️ No se pudo enviar notificación BroadcastChannel:', broadcastError);
-      }
-
-      return fullUser;
     } catch (err) {
-      console.error("❌ Error durante force login:", err);
-
-      if (err.code) {
-        throw new AuthError(err.message, err.code);
-      }
+      console.error("❌ Error en force login:", err);
 
       throw new AuthError(
-        err.message || "Ha ocurrido un error durante el inicio de sesión",
+        err.message || "Ha ocurrido un error durante el inicio de sesión forzado",
         "unknown_error"
       );
     }
-  }, [saveAuthToken, saveUserData, generateWindowId]);
+  }, [generateWindowId, saveAuthToken, saveUserData, restoreCheckoutIntent]);
 
   // ============================================
   // REGISTER
   // ============================================
 
-  const register = useCallback(async (userData) => {
+  const register = useCallback(async (email, password, firstName, lastName, origin = 'web') => {
     try {
-      const result = await registerUser(
-        userData.email,
-        userData.username || userData.email.split("@")[0],
-        userData.password,
-        userData
-      );
-
-      const { token, sessionToken, origin, user: profileData } = result;
-
       const windowId = generateWindowId();
-      
-      saveAuthToken(token, sessionToken, origin, windowId, true);
+      const result = await registerUser(email, password, firstName, lastName, origin, windowId);
 
-      const fullUser = {
-        id: profileData.id,
-        username: profileData.username || profileData.email,
-        email: profileData.email,
-        displayName: profileData.displayName || 
-          `${profileData.firstName || ""} ${profileData.lastName || ""}`.trim(),
-        firstName: profileData.firstName || "",
-        lastName: profileData.lastName || "",
-        phone: profileData.phone || "",
-        company: profileData.company || "",
-        country: profileData.country || "",
-        state: profileData.state || "",
-        city: profileData.city || "",
-        job: profileData.job || "",
-        roles: profileData.roles || [],
-        avatarUrl: null,
-        meta: {},
-      };
+      if (result.token && result.user) {
+        saveAuthToken(result.token, result.sessionToken, origin, windowId);
+        saveUserData(result.user);
+        setUser(result.user);
 
-      const now = Date.now();
-      saveUserData(fullUser);
-      sessionStorage.setItem("token_last_verified", now.toString());
+        console.log(`✅ Registro exitoso: ${result.user.email}`);
 
-      setUser(fullUser);
+        // 🔥 NUEVO: Restaurar intención de checkout si existe
+        const checkoutIntent = restoreCheckoutIntent();
+        if (checkoutIntent) {
+          console.log('✅ Intención de checkout restaurada tras registro');
+        }
 
-      console.log("✅ Registro exitoso:", fullUser);
-
-      return fullUser;
+        return result;
+      } else {
+        throw new AuthError(
+          "No se recibieron credenciales válidas",
+          "invalid_response"
+        );
+      }
     } catch (err) {
-      console.error("❌ Error durante el registro:", err);
+      console.error("❌ Error en registro:", err);
 
-      if (err.code) {
-        throw new AuthError(err.message, err.code);
+      if (err.code === "existing_user_login" || err.code === "user_already_exists") {
+        throw new AuthError(
+          "Este email ya está registrado. Por favor, inicia sesión",
+          "user_already_exists"
+        );
+      } else if (err.code === "invalid_email") {
+        throw new AuthError("El email proporcionado no es válido", "invalid_email");
+      } else if (err.code === "weak_password") {
+        throw new AuthError(
+          "La contraseña es demasiado débil. Debe tener al menos 6 caracteres",
+          "weak_password"
+        );
+      } else if (err.code === "network_error") {
+        throw new AuthError(
+          "Error de conexión. Por favor, verifica tu conexión a internet",
+          "network_error"
+        );
       }
 
       throw new AuthError(
@@ -1424,7 +1388,7 @@ export const AuthProvider = ({ children }) => {
         "unknown_error"
       );
     }
-  }, [saveAuthToken, saveUserData, generateWindowId]);
+  }, [generateWindowId, saveAuthToken, saveUserData, restoreCheckoutIntent]);
 
   // ============================================
   // LOGOUT
@@ -1493,7 +1457,7 @@ export const AuthProvider = ({ children }) => {
         navigate('/');
       }
     }
-  }, [getAuthToken, clearAuthTokens, navigate]); // 🔥 Añadir navigate a dependencias
+  }, [getAuthToken, clearAuthTokens, navigate]);
 
   // ============================================
   // PASSWORD RESET
@@ -1660,7 +1624,7 @@ export const AuthProvider = ({ children }) => {
         forceLogin,
         register,
         logout,
-        loading, // 🔥 EXPORTAR loading
+        loading,
         isAuthenticated,
         revalidate,
         updateUser,
@@ -1671,6 +1635,10 @@ export const AuthProvider = ({ children }) => {
         selectProductForCheckout,
         clearSelectedProduct,
         getToken: getAuthToken,
+        // 🔥 NUEVAS FUNCIONES PARA CHECKOUT
+        saveCheckoutIntent,
+        restoreCheckoutIntent,
+        clearCheckoutIntent,
       }}
     >
       {children}

--- a/src/pages/checkout/CheckoutAuthGuard-simplified.jsx
+++ b/src/pages/checkout/CheckoutAuthGuard-simplified.jsx
@@ -1,0 +1,276 @@
+
+// // src/components/CheckoutAuthGuard/CheckoutAuthGuard.jsx
+// import React, { useEffect, useState } from 'react';
+// import { useNavigate, useLocation } from 'react-router-dom';
+// import './checkoutAuthGuard.scss';
+// import { useAuth } from '../../context/authProviderContext';
+// import AuthModal from '../../components/globalComponents/login/authModal';
+
+// /**
+//  * Componente que envuelve el checkout y gestiona la autenticación
+//  * - Usa tu AuthModal existente
+//  * - Si no está autenticado, muestra el modal y difumina el checkout
+//  * - Guarda el estado del checkout para restaurarlo después del login
+//  */
+// const CheckoutAuthGuard = ({ children }) => {
+//   const { user, loading, isAuthenticated, selectedProduct } = useAuth();
+//   const [modalType, setModalType] = useState(null);
+//   const navigate = useNavigate();
+//   const location = useLocation();
+
+//   useEffect(() => {
+//     // Esperar a que termine la carga inicial
+//     if (loading) {
+//       console.log('⏳ Cargando estado de autenticación...');
+//       return;
+//     }
+
+//     // Si no está autenticado, mostrar modal de login
+//     if (!isAuthenticated()) {
+//       console.log('🔒 Usuario no autenticado en checkout, mostrando modal');
+      
+//       // Guardar la intención de checkout
+//       sessionStorage.setItem('checkout_intent', JSON.stringify({
+//         path: location.pathname,
+//         product: selectedProduct,
+//         timestamp: Date.now()
+//       }));
+      
+//       // Mostrar modal de login (por defecto)
+//       setModalType('login');
+//     } else {
+//       console.log('✅ Usuario autenticado, permitiendo acceso al checkout');
+//       setModalType(null);
+      
+//       // Limpiar intención de checkout una vez autenticado
+//       sessionStorage.removeItem('checkout_intent');
+//     }
+//   }, [loading, isAuthenticated, selectedProduct, location.pathname]);
+
+//   // Detectar cuando el usuario se autentica exitosamente
+//   useEffect(() => {
+//     if (isAuthenticated() && modalType) {
+//       console.log('✅ Usuario autenticado, cerrando modal');
+//       setModalType(null);
+      
+//       // Restaurar intención de checkout si existe
+//       const checkoutIntent = sessionStorage.getItem('checkout_intent');
+//       if (checkoutIntent) {
+//         try {
+//           const intent = JSON.parse(checkoutIntent);
+//           console.log('♻️ Restaurando intención de checkout:', intent);
+//           sessionStorage.removeItem('checkout_intent');
+//         } catch (e) {
+//           console.error('❌ Error al restaurar intención de checkout:', e);
+//         }
+//       }
+//     }
+//   }, [user, modalType, isAuthenticated]);
+
+//   const handleModalClose = () => {
+//     console.log('❌ Usuario cerró modal sin autenticarse');
+//     sessionStorage.removeItem('checkout_intent');
+//     navigate('/checkout'); // Volver a la página de precios
+//   };
+
+//   // Mostrar loading mientras se verifica autenticación
+//   if (loading) {
+//     return (
+//       <div className="checkout-auth-loading">
+//         <div className="spinner"></div>
+//         <p>Verificando sesión...</p>
+//       </div>
+//     );
+//   }
+
+//   // Si está autenticado, mostrar el checkout normal
+//   if (isAuthenticated()) {
+//     return <>{children}</>;
+//   }
+
+//   // Si no está autenticado, mostrar checkout difuminado + modal
+//   return (
+//     <div className="checkout-auth-guard">
+//       {/* Backdrop con checkout difuminado */}
+//       <div className="checkout-preview-blurred">
+//         {children}
+//       </div>
+
+//       {/* Overlay informativo */}
+//       <div className="checkout-auth-overlay">
+//         <div className="auth-prompt">
+//           <div className="prompt-icon">🔒</div>
+//           <h2>Inicia sesión para continuar</h2>
+//           <p>Estás a punto de completar tu compra</p>
+//           {selectedProduct && (
+//             <div className="product-info">
+//               <span className="product-icon">📦</span>
+//               <span className="product-name">{selectedProduct.name}</span>
+//             </div>
+//           )}
+//         </div>
+//       </div>
+
+//       {/* Tu AuthModal existente */}
+//       {modalType && (
+//         <AuthModal 
+//           modalType={modalType} 
+//           setModalType={(type) => {
+//             if (!type) {
+//               // Si el usuario cierra el modal sin autenticarse
+//               handleModalClose();
+//             } else {
+//               setModalType(type);
+//             }
+//           }}
+//         />
+//       )}
+//     </div>
+//   );
+// };
+
+// export default CheckoutAuthGuard;
+
+
+
+
+
+
+
+// src/components/CheckoutAuthGuard/CheckoutAuthGuard.jsx
+import React, { useEffect, useState, useRef } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import './checkoutAuthGuard.scss';
+import { useAuth } from '../../context/authProviderContext';
+import AuthModal from '../../components/globalComponents/login/authModal';
+
+/**
+ * Componente que envuelve el checkout y gestiona la autenticación
+ * - Usa tu AuthModal existente
+ * - Si no está autenticado, muestra el modal y difumina el checkout
+ * - Guarda el estado del checkout para restaurarlo después del login
+ */
+const CheckoutAuthGuard = ({ children }) => {
+  const { loading, isAuthenticated, selectedProduct } = useAuth();
+  const [modalType, setModalType] = useState(null);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const wasAuthenticatedRef = useRef(false);
+
+  useEffect(() => {
+    // Esperar a que termine la carga inicial
+    if (loading) {
+      console.log('⏳ Cargando estado de autenticación...');
+      return;
+    }
+
+    const authenticated = isAuthenticated();
+
+    // Si no está autenticado y no hay modal abierto, abrirlo
+    if (!authenticated && !modalType) {
+      console.log('🔒 Usuario no autenticado en checkout, mostrando modal');
+      
+      // Guardar la intención de checkout
+      sessionStorage.setItem('checkout_intent', JSON.stringify({
+        path: location.pathname,
+        product: selectedProduct,
+        timestamp: Date.now()
+      }));
+      
+      // Mostrar modal de login (por defecto)
+      setModalType('login');
+      wasAuthenticatedRef.current = false;
+    } 
+    // Si está autenticado y había un modal abierto, cerrarlo
+    else if (authenticated && modalType && !wasAuthenticatedRef.current) {
+      console.log('✅ Autenticación completada, cerrando modal');
+      setModalType(null);
+      sessionStorage.removeItem('checkout_intent');
+      wasAuthenticatedRef.current = true;
+    }
+    // Si está autenticado desde el inicio, marcar como autenticado
+    else if (authenticated) {
+      console.log('✅ Usuario autenticado, permitiendo acceso al checkout');
+      wasAuthenticatedRef.current = true;
+      
+      // Si hay modal abierto pero está autenticado, cerrarlo
+      if (modalType) {
+        setModalType(null);
+        sessionStorage.removeItem('checkout_intent');
+      }
+    }
+  }, [loading, isAuthenticated, selectedProduct, location.pathname, modalType]);
+
+  const handleModalClose = (type) => {
+    console.log('🔄 handleModalClose llamado con:', type);
+    
+    // Si type es null, el usuario quiere cerrar el modal
+    if (type === null) {
+      // Si NO está autenticado, redirigir al home
+      if (!isAuthenticated()) {
+        console.log('❌ Usuario cerró modal sin autenticarse, redirigiendo...');
+        sessionStorage.removeItem('checkout_intent');
+        navigate('/');
+      } else {
+        // Si está autenticado, solo cerrar el modal
+        console.log('✅ Modal cerrado (usuario autenticado)');
+        setModalType(null);
+        sessionStorage.removeItem('checkout_intent');
+      }
+    } else {
+      // Si hay un type (cambio entre login/register), mantener el modal
+      console.log('🔄 Cambiando tipo de modal a:', type);
+      setModalType(type);
+    }
+  };
+
+  // Mostrar loading mientras se verifica autenticación
+  if (loading) {
+    return (
+      <div className="checkout-auth-loading">
+        <div className="spinner"></div>
+        <p>Verificando sesión...</p>
+      </div>
+    );
+  }
+
+  // Si está autenticado, mostrar el checkout normal
+  if (isAuthenticated()) {
+    return <>{children}</>;
+  }
+
+  // Si no está autenticado, mostrar checkout difuminado + modal
+  return (
+    <div className="checkout-auth-guard">
+      {/* Backdrop con checkout difuminado */}
+      <div className="checkout-preview-blurred">
+        {children}
+      </div>
+
+      {/* Overlay informativo */}
+      <div className="checkout-auth-overlay">
+        <div className="auth-prompt">
+          <div className="prompt-icon">🔒</div>
+          <h2>Inicia sesión para continuar</h2>
+          <p>Estás a punto de completar tu compra</p>
+          {selectedProduct && (
+            <div className="product-info">
+              <span className="product-icon">📦</span>
+              <span className="product-name">{selectedProduct.name}</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Tu AuthModal existente */}
+      {modalType && (
+        <AuthModal 
+          modalType={modalType} 
+          setModalType={handleModalClose}
+        />
+      )}
+    </div>
+  );
+};
+
+export default CheckoutAuthGuard;

--- a/src/pages/checkout/checkoutAuthGuard.scss
+++ b/src/pages/checkout/checkoutAuthGuard.scss
@@ -1,0 +1,142 @@
+
+// src/components/CheckoutAuthGuard/CheckoutAuthGuard.scss
+
+.checkout-auth-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 60vh;
+    gap: 1rem;
+  
+    .spinner {
+      width: 40px;
+      height: 40px;
+      border: 4px solid #f3f3f3;
+      border-top: 4px solid #007bff;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+  
+    p {
+      color: #666;
+      font-size: 1rem;
+    }
+  }
+  
+  .checkout-auth-guard {
+    position: relative;
+    min-height: 100vh;
+  
+    .checkout-preview-blurred {
+      filter: blur(8px);
+      pointer-events: none;
+      user-select: none;
+      opacity: 0.3;
+    }
+  
+    .checkout-auth-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 9998; // Justo debajo del AuthModal (que tiene z-index: 9999)
+      pointer-events: none; // No bloquea el modal
+  
+      .auth-prompt {
+        background: white;
+        padding: 2.5rem;
+        border-radius: 16px;
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+        text-align: center;
+        max-width: 400px;
+        animation: fadeIn 0.5s ease;
+  
+        .prompt-icon {
+          font-size: 3rem;
+          margin-bottom: 1rem;
+        }
+  
+        h2 {
+          font-size: 1.5rem;
+          font-weight: 700;
+          color: #1a1a1a;
+          margin-bottom: 0.5rem;
+        }
+  
+        p {
+          color: #666;
+          font-size: 1rem;
+          margin-bottom: 1.5rem;
+        }
+  
+        .product-info {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.5rem;
+          background: #f0f9ff;
+          color: #0066cc;
+          padding: 0.75rem 1.25rem;
+          border-radius: 12px;
+          font-size: 0.95rem;
+          font-weight: 600;
+          margin-top: 0.5rem;
+  
+          .product-icon {
+            font-size: 1.3rem;
+          }
+        }
+      }
+    }
+  }
+  
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  
+  // Responsive
+  @media (max-width: 600px) {
+    .checkout-auth-guard {
+      .checkout-auth-overlay {
+        padding: 1rem;
+  
+        .auth-prompt {
+          padding: 2rem 1.5rem;
+  
+          .prompt-icon {
+            font-size: 2.5rem;
+          }
+  
+          h2 {
+            font-size: 1.25rem;
+          }
+  
+          p {
+            font-size: 0.9rem;
+          }
+  
+          .product-info {
+            font-size: 0.85rem;
+            padding: 0.6rem 1rem;
+          }
+        }
+      }
+    }
+  }

--- a/src/pages/checkout/checkoutPage.jsx
+++ b/src/pages/checkout/checkoutPage.jsx
@@ -1,4 +1,682 @@
 
+// // src/pages/CheckoutPage/CheckoutPage.jsx
+// import React, { useState, useEffect } from 'react';
+// import { useNavigate } from 'react-router-dom';
+// import { loadStripe } from '@stripe/stripe-js';
+// import { Elements, PaymentElement, useStripe, useElements } from '@stripe/react-stripe-js';
+// import { PayPalScriptProvider, PayPalButtons } from '@paypal/react-paypal-js';
+// import { useAuth } from '../../context/authProviderContext';
+// import './checkoutPage.scss';
+// import Menu from '../../components/globalComponents/headerMenu/menu';
+
+// const STRIPE_PUBLIC_KEY =
+//   process.env.REACT_APP_STRIPE_PUBLIC_KEY ||
+//   'pk_live_51S5vXO2Lf1dW7ltx3Z3mGvdovsVl5i2GMBCL79fKhqBxAVRE42TA3D50gMHuN56TJGRqK0l5bFkKkCqCFciFbwJy00rOO2qfWq';
+// const PAYPAL_CLIENT_ID = 'TU_CLIENT_ID_PAYPAL';
+// const API_URL = process.env.REACT_APP_WC_API_URL || 'https://api.olawee.com/wp-json';
+
+// const stripePromise = loadStripe(STRIPE_PUBLIC_KEY);
+
+// // ⚙️ Configura aquí qué productos son "trial" (gratis 14 días)
+// const TRIAL_PRODUCT_IDS = [78]; // <-- pon aquí los IDs Woo del/los producto(s) con prueba
+// const FUTURE_CHARGE_EUR = 30;   // cargo después de la prueba (en euros)
+
+// const api = {
+//   async createOrder(orderData, token) {
+//     const response = await fetch(`${API_URL}/olawee/v1/orders`, {
+//       method: 'POST',
+//       headers: {
+//         'Content-Type': 'application/json',
+//         Authorization: `Bearer ${token}`,
+//       },
+//       body: JSON.stringify(orderData),
+//     });
+
+//     if (!response.ok) {
+//       const error = await response.json();
+//       throw new Error(error.message || 'Error al crear orden');
+//     }
+//     return response.json();
+//   },
+
+//   async createPaymentIntent(orderId, amount, token) {
+//     // amount llega en euros -> lo pasamos a céntimos
+//     const requestBody = {
+//       order_id: orderId,
+//       amount: Math.round(Number(amount || 0) * 100),
+//       currency: 'eur',
+//     };
+
+//     const response = await fetch(`${API_URL}/olawee-stripe/v1/create-payment-intent`, {
+//       method: 'POST',
+//       headers: {
+//         'Content-Type': 'application/json',
+//         Authorization: `Bearer ${token}`,
+//       },
+//       body: JSON.stringify(requestBody),
+//     });
+
+//     const data = await response.json();
+//     if (!response.ok) {
+//       throw new Error(data.message || 'Error al crear Payment Intent');
+//     }
+//     return data;
+//   },
+
+//   async updateOrder(orderId, updateData, token) {
+//     const response = await fetch(`${API_URL}/olawee/v1/orders/${orderId}/update`, {
+//       method: 'POST',
+//       headers: {
+//         'Content-Type': 'application/json',
+//         Authorization: `Bearer ${token}`,
+//       },
+//       body: JSON.stringify(updateData),
+//     });
+
+//     const data = await response.json();
+//     if (!response.ok) {
+//       throw new Error(data?.message || 'No se pudo actualizar el pedido');
+//     }
+//     return data;
+//   },
+
+//   async confirmPayment(orderId, paymentIntentId, token, setupIntentId = null) {
+//     const body = {
+//       order_id: orderId,
+//     };
+
+//     // Enviar el parámetro correcto según el tipo
+//     if (setupIntentId) {
+//       body.setup_intent_id = setupIntentId;
+//     }
+//     if (paymentIntentId) {
+//       body.payment_intent_id = paymentIntentId;
+//     }
+
+//     const response = await fetch(`${API_URL}/olawee-stripe/v1/confirm-payment`, {
+//       method: 'POST',
+//       headers: {
+//         'Content-Type': 'application/json',
+//         Authorization: `Bearer ${token}`,
+//       },
+//       body: JSON.stringify(body),
+//     });
+
+//     const data = await response.json();
+    
+//     if (!response.ok) {
+//       throw new Error(data?.message || 'Error al confirmar el pago');
+//     }
+    
+//     return data;
+//   },
+
+//   async verifyIntent(orderId, paymentIntentId, token) {
+//     const response = await fetch(`${API_URL}/olawee-stripe/v1/verify-intent`, {
+//       method: 'POST',
+//       headers: {
+//         'Content-Type': 'application/json',
+//         Authorization: `Bearer ${token}`,
+//       },
+//       body: JSON.stringify({
+//         order_id: orderId,
+//         payment_intent_id: paymentIntentId
+//       }),
+//     });
+
+//     const data = await response.json();
+//     if (!response.ok) {
+//       throw new Error(data?.message || 'No se pudo verificar el pago con Stripe');
+//     }
+//     return data;
+//   },
+
+  
+// };
+
+
+
+// // ──────────────────────────────────────────────────────────────
+// // Formulario de pago Stripe
+// function StripePaymentForm({ orderId, amount, onSuccess, onError, isSetupIntent = false }) {
+//   const stripe = useStripe();
+//   const elements = useElements();
+//   const [isProcessing, setIsProcessing] = useState(false);
+
+//   const handlePayment = async () => {
+//     console.log('Payment Form Details:', {
+//       isSetupIntent,
+//       amount,
+//       stripeReady: !!stripe,
+//       elementsReady: !!elements
+//     });
+//     if (!stripe || !elements) {
+//       onError('Stripe no está listo');
+//       return;
+//     }
+
+//     setIsProcessing(true);
+
+//     try {
+//       if (isSetupIntent || amount === 0) {
+//         console.log('Intentando confirmSetup');
+//         // Setup Intent → guardar método (0€ ahora)
+//         const { error, setupIntent } = await stripe.confirmSetup({
+//           elements,
+//           confirmParams: {
+//             return_url: `${window.location.origin}/order-confirmation/${orderId}?trial=true`,
+//           },
+//           redirect: 'if_required',
+//         });
+//         console.log('Setup Intent Result:', { error, setupIntent });
+//         if (error) {
+//           onError(error.message);
+//         } else if (setupIntent && setupIntent.status === 'succeeded') {
+//           onSuccess({
+//             id: setupIntent.id,
+//             type: 'setup_intent',
+//             status: 'succeeded',
+//           });
+//         } else {
+//           console.log('Intentando confirmPayment');
+//           onError('No se pudo completar el guardado del método de pago');
+//         }
+//       } else {
+//         // Payment Intent → cobro normal
+//         const { error, paymentIntent } = await stripe.confirmPayment({
+//           elements,
+//           confirmParams: {
+//             return_url: `${window.location.origin}/order-confirmation/${orderId}`,
+//           },
+//           redirect: 'if_required',
+//         });
+//         console.log('Payment Intent Result:', { error, paymentIntent });
+
+//         if (error) {
+//           onError(error.message);
+//         } else if (paymentIntent && paymentIntent.status === 'succeeded') {
+//           onSuccess(paymentIntent);
+//         } else if (paymentIntent && paymentIntent.status === 'processing') {
+//           onSuccess(paymentIntent);
+//         } else {
+//           onError('El pago requiere acción adicional');
+//         }
+//       }
+//     } catch (err) {
+//       onError(err.message || 'Error procesando el pago');
+//     } finally {
+//       setIsProcessing(false);
+//     }
+//   };
+
+//   return (
+//     <div className="payment-form">
+//       <PaymentElement />
+//       <button onClick={handlePayment} disabled={!stripe || isProcessing} className="btn-pay">
+//         {isProcessing ? 'Procesando...' : amount === 0 ? 'Confirmar' : `Pagar ${Number(amount).toFixed(2)}€`}
+//       </button>
+//       {amount === 0 && (
+//         <p className="trial-notice">
+//           Periodo de prueba gratuito de 14 días. Se te cobrará {FUTURE_CHARGE_EUR}€ después del periodo de prueba.
+//         </p>
+//       )}
+//     </div>
+//   );
+// }
+
+// // ──────────────────────────────────────────────────────────────
+// // Página de Checkout
+// const CheckoutPage = () => {
+//   const navigate = useNavigate();
+//   const { selectedProduct, user, isAuthenticated, clearSelectedProduct, getToken } = useAuth();
+
+//   const [step, setStep] = useState('billing');
+//   const [paymentMethod, setPaymentMethod] = useState('stripe');
+//   const [orderId, setOrderId] = useState(null);
+//   const [clientSecret, setClientSecret] = useState(null);
+//   const [isLoading, setIsLoading] = useState(false);
+//   const [error, setError] = useState(null);
+//   const [isFreeTrial, setIsFreeTrial] = useState(false);
+
+//   //es-lint-disable-next-line no-unused-vars
+//   const [futureCharge, setFutureCharge] = useState(null);
+
+//   const [billingData, setBillingData] = useState({
+//     first_name: '',
+//     last_name: '',
+//     email: '',
+//     phone: '',
+//     address_1: '',
+//     city: '',
+//     postcode: '',
+//     country: 'ES',
+//   });
+
+//   // Rellenar datos con el usuario logueado
+//   useEffect(() => {
+//     if (user) {
+//       setBillingData((prev) => ({
+//         ...prev,
+//         first_name: user.firstName || prev.first_name,
+//         last_name: user.lastName || prev.last_name,
+//         email: user.email || prev.email,
+//         phone: user.phone || prev.phone,
+//         address_1: prev.address_1 || '',
+//         city: prev.city || '',
+//         postcode: prev.postcode || '',
+//       }));
+//     }
+//   }, [user]);
+
+//   useEffect(() => {
+//     if (!isAuthenticated) {
+//       window.dispatchEvent(new CustomEvent('openAuthModal', { detail: { type: 'login' } }));
+//       navigate('/prices');
+//       return;
+//     }
+
+//     if (!selectedProduct) {
+//       const pendingProduct = sessionStorage.getItem('pending_product');
+//       const savedProduct = sessionStorage.getItem('selected_product');
+
+//       if (pendingProduct || savedProduct) {
+//         sessionStorage.removeItem('pending_product');
+//       } else {
+//         navigate('/prices');
+//       }
+//     }
+//   }, [isAuthenticated, selectedProduct, navigate]);
+
+//   if (!selectedProduct) return null;
+
+//   // Detectar si el producto seleccionado es "trial"
+//   const isTrialProduct = TRIAL_PRODUCT_IDS.includes(Number(selectedProduct.id));
+
+//   // El total a cobrar AHORA:
+//   const totalNow = isTrialProduct ? 0 : Number(parseFloat(selectedProduct.price) || 0);
+
+//   const isFormValid = () => {
+//     return (
+//       billingData.first_name &&
+//       billingData.last_name &&
+//       billingData.email &&
+//       billingData.email.includes('@') &&
+//       billingData.address_1 &&
+//       billingData.city &&
+//       billingData.postcode
+//     );
+//   };
+
+//   const updateField = (field, value) => {
+//     setBillingData((prev) => ({ ...prev, [field]: value }));
+//   };
+
+//   const createOrder = async () => {
+//     setIsLoading(true);
+//     setError(null);
+
+//     try {
+//       const { token } = getToken();
+//       if (!token) throw new Error('No se encontró token de autenticación');
+
+//       const orderData = {
+//         payment_method: paymentMethod === 'stripe' ? 'stripe' : 'ppcp-gateway',
+//         payment_method_title: paymentMethod === 'stripe' ? 'Tarjeta / Klarna' : 'PayPal',
+//         set_paid: false,
+//         billing: billingData,
+//         line_items: [
+//           {
+//             product_id: selectedProduct.id,
+//             quantity: 1,
+//           },
+//         ],
+//         customer_id: user?.id,
+//         status: 'pending',
+//       };
+
+//       const order = await api.createOrder(orderData, token);
+//       if (!order.id) {
+//         throw new Error(order.message || 'Error al crear la orden');
+//       }
+
+//       setOrderId(order.id);
+
+//       if (paymentMethod === 'stripe') {
+//         // amount a Stripe: 0 si trial, precio normal si no
+//         const paymentData = await api.createPaymentIntent(order.id, totalNow, token);
+
+//         // CASO 1: Trial
+//         if (isTrialProduct || paymentData.free_trial) {
+//           setIsFreeTrial(true);
+//           setFutureCharge(FUTURE_CHARGE_EUR);
+
+//           if (paymentData.client_secret) {
+//             setClientSecret(paymentData.client_secret);
+//             setStep('payment');
+//           } else {
+//             // Fallback sin método guardado (backend ya pone la orden en processing)
+//             clearSelectedProduct();
+//             navigate(`/order-confirmation/${order.id}?trial=true`);
+//           }
+//         }
+//         // CASO 2: Pago normal
+//         else if (paymentData.client_secret) {
+//           setIsFreeTrial(false);
+//           setClientSecret(paymentData.client_secret);
+//           setStep('payment');
+//         } else {
+//           throw new Error('Respuesta inválida del servidor');
+//         }
+//       } else {
+//         // PayPal
+//         setStep('payment');
+//       }
+//     } catch (err) {
+//       setError(err.message || 'Error al procesar la orden');
+//     } finally {
+//       setIsLoading(false);
+//     }
+//   };
+
+
+// const handlePaymentSuccess = async (paymentDetails) => {
+//   try {
+//     const { token } = getToken();
+
+//     // Tipo de flujo
+//     const isSetup = paymentDetails?.type === 'setup_intent' || isFreeTrial || totalNow === 0;
+//     const isStripePI =
+//       (paymentDetails?.id && paymentDetails.id.startsWith('pi_')) ||
+//       paymentDetails?.object === 'payment_intent';
+//     const isStripeSI =
+//       (paymentDetails?.id && paymentDetails.id.startsWith('seti_')) ||
+//       paymentDetails?.type === 'setup_intent';
+
+//     // Plan A: confirmar en backend (Stripe)
+//     if (isStripeSI || isStripePI) {
+//       try {
+//         await api.confirmPayment(
+//           orderId,
+//           isStripePI ? paymentDetails.id : null,  // payment_intent_id si aplica
+//           token,
+//           isStripeSI ? paymentDetails.id : null   // setup_intent_id si aplica
+//         );
+//       } catch (confirmError) {
+//         // No rompemos el flujo; continuamos con verify-intent si es PI
+//         console.warn('[Checkout] confirm-payment falló, seguimos con verify-intent si es PI:', confirmError);
+//       }
+//     }
+
+//     // Plan B: verificar directamente el PaymentIntent en Stripe
+//     if (isStripePI) {
+//       try {
+//         await api.verifyIntent(orderId, paymentDetails.id, token);
+//       } catch (verifyErr) {
+//         console.warn('[Checkout] verify-intent no pudo confirmar el pedido:', verifyErr);
+//       }
+//     }
+
+//     // Pasarelas externas (PayPal, etc.)
+//     if (!isStripePI && !isStripeSI) {
+//       const txId =
+//         paymentDetails?.id ||
+//         paymentDetails?.purchase_units?.[0]?.payments?.captures?.[0]?.id ||
+//         paymentDetails?.purchase_units?.[0]?.payments?.authorizations?.[0]?.id ||
+//         'external';
+
+//       try {
+//         await api.updateOrder(
+//           orderId,
+//           {
+//             status: 'processing',
+//             transaction_id: txId,
+//             add_note: 'Pago aprobado por pasarela externa',
+//           },
+//           token
+//         );
+//       } catch (e) {
+//         console.warn('[Checkout] updateOrder (pasarela externa) avisó:', e);
+//       }
+//     }
+
+//     clearSelectedProduct();
+//     navigate(isSetup ? `/order-confirmation/${orderId}?trial=true` : `/order-confirmation/${orderId}`);
+//   } catch (err) {
+//     console.error('[Checkout] Error final en handlePaymentSuccess:', err);
+//     clearSelectedProduct();
+//     navigate(`/order-confirmation/${orderId}`);
+//   }
+// };
+
+
+
+//   const handlePaymentError = (errorMessage) => {
+//     setError(errorMessage);
+//   };
+
+//   return (
+//     <>
+//       <Menu />
+//       <div className="checkout-page mt-4">
+//         <div className="checkout-container">
+//           <h1 className="checkout-title">Finalizar compra</h1>
+
+//           <div className="checkout-grid">
+//             <div className="checkout-main">
+//               {step === 'billing' && (
+//                 <div className="checkout-section">
+//                   <h2>Datos de facturación</h2>
+
+//                   <div className="form-grid">
+//                     <div className="form-field">
+//                       <label>Nombre *</label>
+//                       <input
+//                         type="text"
+//                         value={billingData.first_name}
+//                         onChange={(e) => updateField('first_name', e.target.value)}
+//                         placeholder="Tu nombre"
+//                       />
+//                     </div>
+
+//                     <div className="form-field">
+//                       <label>Apellidos *</label>
+//                       <input
+//                         type="text"
+//                         value={billingData.last_name}
+//                         onChange={(e) => updateField('last_name', e.target.value)}
+//                         placeholder="Tus apellidos"
+//                       />
+//                     </div>
+
+//                     <div className="form-field full-width">
+//                       <label>Email *</label>
+//                       <input
+//                         type="email"
+//                         value={billingData.email}
+//                         onChange={(e) => updateField('email', e.target.value)}
+//                         placeholder="tu@email.com"
+//                       />
+//                     </div>
+
+//                     <div className="form-field full-width">
+//                       <label>Teléfono</label>
+//                       <input
+//                         type="tel"
+//                         value={billingData.phone}
+//                         onChange={(e) => updateField('phone', e.target.value)}
+//                         placeholder="+34 600 000 000"
+//                       />
+//                     </div>
+
+//                     <div className="form-field full-width">
+//                       <label>Dirección *</label>
+//                       <input
+//                         type="text"
+//                         value={billingData.address_1}
+//                         onChange={(e) => updateField('address_1', e.target.value)}
+//                         placeholder="Calle, número, piso..."
+//                       />
+//                     </div>
+
+//                     <div className="form-field">
+//                       <label>Ciudad *</label>
+//                       <input
+//                         type="text"
+//                         value={billingData.city}
+//                         onChange={(e) => updateField('city', e.target.value)}
+//                         placeholder="Tu ciudad"
+//                       />
+//                     </div>
+
+//                     <div className="form-field">
+//                       <label>Código postal *</label>
+//                       <input
+//                         type="text"
+//                         value={billingData.postcode}
+//                         onChange={(e) => updateField('postcode', e.target.value)}
+//                         placeholder="28000"
+//                       />
+//                     </div>
+//                   </div>
+
+//                   <div className="payment-method-section">
+//                     <h3>Método de pago</h3>
+//                     <div className="payment-methods">
+//                       <label className="payment-option">
+//                         <input
+//                           type="radio"
+//                           name="payment"
+//                           value="stripe"
+//                           checked={paymentMethod === 'stripe'}
+//                           onChange={(e) => setPaymentMethod(e.target.value)}
+//                         />
+//                         <span>Tarjeta de crédito / Klarna</span>
+//                       </label>
+
+//                       <label className="payment-option">
+//                         <input
+//                           type="radio"
+//                           name="payment"
+//                           value="paypal"
+//                           checked={paymentMethod === 'paypal'}
+//                           onChange={(e) => setPaymentMethod(e.target.value)}
+//                           disabled={isTrialProduct} // En trial, forzamos Stripe (para guardar método)
+//                         />
+//                         <span>PayPal</span>
+//                       </label>
+//                     </div>
+//                   </div>
+
+//                   {error && <div className="error-message">{error}</div>}
+
+//                   <button onClick={createOrder} disabled={!isFormValid() || isLoading} className="btn-continue">
+//                     {isLoading ? 'Creando orden...' : 'Continuar al pago'}
+//                   </button>
+//                 </div>
+//               )}
+
+//               {step === 'payment' && paymentMethod === 'stripe' && clientSecret && (
+//                 <div className="checkout-section">
+//                   <h2>{totalNow === 0 ? 'Guardar método de pago' : 'Completar pago'}</h2>
+
+//                   {error && <div className="error-message">{error}</div>}
+
+//                   <Elements stripe={stripePromise} options={{ clientSecret }}>
+//                     <StripePaymentForm
+//                       orderId={orderId}
+//                       amount={totalNow}
+//                       onSuccess={handlePaymentSuccess}
+//                       onError={handlePaymentError}
+//                       isSetupIntent={totalNow === 0}
+//                     />
+//                   </Elements>
+//                 </div>
+//               )}
+
+//               {step === 'payment' && paymentMethod === 'paypal' && (
+//                 <div className="checkout-section">
+//                   <h2>Pagar con PayPal</h2>
+//                   {error && <div className="error-message">{error}</div>}
+//                   <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID, currency: 'EUR' }}>
+//                     <PayPalButtons
+//                       createOrder={(data, actions) => {
+//                         return actions.order.create({
+//                           purchase_units: [
+//                             {
+//                               reference_id: orderId.toString(),
+//                               amount: {
+//                                 value: Number(totalNow).toFixed(2),
+//                                 currency_code: 'EUR',
+//                               },
+//                             },
+//                           ],
+//                         });
+//                       }}
+//                       onApprove={async (data, actions) => {
+//                         const details = await actions.order.capture();
+//                         handlePaymentSuccess(details);
+//                       }}
+//                       onError={() => handlePaymentError('Error con PayPal')}
+//                     />
+//                   </PayPalScriptProvider>
+//                 </div>
+//               )}
+//             </div>
+
+//             <div className="checkout-sidebar">
+//               <div className="order-summary">
+//                 <h3>Resumen del pedido</h3>
+
+//                 <div className="product-summary">
+//                   <div className="product-name">{selectedProduct.name}</div>
+//                   <div className="product-price">
+//                     {isTrialProduct ? (
+//                       <>
+//                         <span className="trial-badge">Prueba gratuita</span>
+//                         <span className="future-price">
+//                         {(futureCharge ?? FUTURE_CHARGE_EUR).toFixed(2)}€ después de 14 días
+//                         </span>
+//                       </>
+//                     ) : (
+//                       `${Number(selectedProduct.price || 0).toFixed(2)}€`
+//                     )}
+//                   </div>
+//                 </div>
+
+//                 <div className="summary-total">
+//                   <span>Total {totalNow === 0 ? 'hoy' : ''}:</span>
+//                   <span>{totalNow === 0 ? '0€' : `${Number(totalNow).toFixed(2)}€`}</span>
+//                 </div>
+
+//                 <div className="summary-benefits">
+//                   <div>{totalNow === 0 ? '14 días de prueba gratuita' : 'Entrega inmediata'}</div>
+//                   <div>Pago 100% seguro</div>
+//                   <div>Soporte incluido</div>
+//                   {totalNow === 0 && <div>Cancela cuando quieras</div>}
+//                 </div>
+//               </div>
+//             </div>
+//           </div>
+//         </div>
+//       </div> 
+//     </>
+//   );
+// };
+
+// export default CheckoutPage;
+
+
+
+
+
+
+
+
+
+
+
+
+
 // src/pages/CheckoutPage/CheckoutPage.jsx
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -8,6 +686,7 @@ import { PayPalScriptProvider, PayPalButtons } from '@paypal/react-paypal-js';
 import { useAuth } from '../../context/authProviderContext';
 import './checkoutPage.scss';
 import Menu from '../../components/globalComponents/headerMenu/menu';
+import CheckoutAuthGuard from './CheckoutAuthGuard-simplified';
 
 const STRIPE_PUBLIC_KEY =
   process.env.REACT_APP_STRIPE_PUBLIC_KEY ||
@@ -228,23 +907,12 @@ function StripePaymentForm({ orderId, amount, onSuccess, onError, isSetupIntent 
 // Página de Checkout
 const CheckoutPage = () => {
   const navigate = useNavigate();
-  const { selectedProduct, user, isAuthenticated, clearSelectedProduct, getToken } = useAuth();
-
-  const [step, setStep] = useState('billing');
-  const [paymentMethod, setPaymentMethod] = useState('stripe');
-  const [orderId, setOrderId] = useState(null);
-  const [clientSecret, setClientSecret] = useState(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [isFreeTrial, setIsFreeTrial] = useState(false);
-
-  //es-lint-disable-next-line no-unused-vars
-  const [futureCharge, setFutureCharge] = useState(null);
+  const { user, getToken, selectedProduct, clearSelectedProduct } = useAuth();
 
   const [billingData, setBillingData] = useState({
-    first_name: '',
-    last_name: '',
-    email: '',
+    first_name: user?.firstName || '',
+    last_name: user?.lastName || '',
+    email: user?.email || '',
     phone: '',
     address_1: '',
     city: '',
@@ -252,7 +920,32 @@ const CheckoutPage = () => {
     country: 'ES',
   });
 
-  // Rellenar datos con el usuario logueado
+  const [paymentMethod, setPaymentMethod] = useState('stripe');
+  const [step, setStep] = useState('billing');
+  const [orderId, setOrderId] = useState(null);
+  const [clientSecret, setClientSecret] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const updateField = (field, value) => {
+    setBillingData((prev) => ({ ...prev, [field]: value }));
+    setError(null);
+  };
+
+  const isTrialProduct = selectedProduct && TRIAL_PRODUCT_IDS.includes(Number(selectedProduct.id));
+  
+  const productPrice = Number(selectedProduct?.price || 0);
+  const totalNow = isTrialProduct ? 0 : productPrice;
+  const futureCharge = isTrialProduct ? FUTURE_CHARGE_EUR : null;
+
+  // 🔥 Si no hay producto seleccionado, redirigir (el guard ya se encarga de la autenticación)
+  useEffect(() => {
+    if (!selectedProduct) {
+      console.log('⚠️ No hay producto seleccionado, redirigiendo a pricing');
+      navigate('/prices');
+    }
+  }, [selectedProduct, navigate]);
+
   useEffect(() => {
     if (user) {
       setBillingData((prev) => ({
@@ -260,58 +953,21 @@ const CheckoutPage = () => {
         first_name: user.firstName || prev.first_name,
         last_name: user.lastName || prev.last_name,
         email: user.email || prev.email,
-        phone: user.phone || prev.phone,
-        address_1: prev.address_1 || '',
-        city: prev.city || '',
-        postcode: prev.postcode || '',
       }));
     }
   }, [user]);
 
-  useEffect(() => {
-    if (!isAuthenticated) {
-      window.dispatchEvent(new CustomEvent('openAuthModal', { detail: { type: 'login' } }));
-      navigate('/prices');
-      return;
-    }
-
-    if (!selectedProduct) {
-      const pendingProduct = sessionStorage.getItem('pending_product');
-      const savedProduct = sessionStorage.getItem('selected_product');
-
-      if (pendingProduct || savedProduct) {
-        sessionStorage.removeItem('pending_product');
-      } else {
-        navigate('/prices');
-      }
-    }
-  }, [isAuthenticated, selectedProduct, navigate]);
-
-  if (!selectedProduct) return null;
-
-  // Detectar si el producto seleccionado es "trial"
-  const isTrialProduct = TRIAL_PRODUCT_IDS.includes(Number(selectedProduct.id));
-
-  // El total a cobrar AHORA:
-  const totalNow = isTrialProduct ? 0 : Number(parseFloat(selectedProduct.price) || 0);
-
   const isFormValid = () => {
-    return (
-      billingData.first_name &&
-      billingData.last_name &&
-      billingData.email &&
-      billingData.email.includes('@') &&
-      billingData.address_1 &&
-      billingData.city &&
-      billingData.postcode
-    );
-  };
-
-  const updateField = (field, value) => {
-    setBillingData((prev) => ({ ...prev, [field]: value }));
+    const required = ['first_name', 'last_name', 'email', 'address_1', 'city', 'postcode'];
+    return required.every((field) => billingData[field]?.trim());
   };
 
   const createOrder = async () => {
+    if (!isFormValid()) {
+      setError('Por favor, completa todos los campos obligatorios');
+      return;
+    }
+
     setIsLoading(true);
     setError(null);
 
@@ -320,9 +976,7 @@ const CheckoutPage = () => {
       if (!token) throw new Error('No se encontró token de autenticación');
 
       const orderData = {
-        payment_method: paymentMethod === 'stripe' ? 'stripe' : 'ppcp-gateway',
-        payment_method_title: paymentMethod === 'stripe' ? 'Tarjeta / Klarna' : 'PayPal',
-        set_paid: false,
+        customer_id: user?.id,
         billing: billingData,
         line_items: [
           {
@@ -330,343 +984,305 @@ const CheckoutPage = () => {
             quantity: 1,
           },
         ],
-        customer_id: user?.id,
-        status: 'pending',
+        payment_method: paymentMethod,
+        payment_method_title: paymentMethod === 'stripe' ? 'Tarjeta' : 'PayPal',
       };
 
-      const order = await api.createOrder(orderData, token);
-      if (!order.id) {
-        throw new Error(order.message || 'Error al crear la orden');
-      }
+      const orderResponse = await api.createOrder(orderData, token);
+      console.log('✅ Orden creada:', orderResponse);
+      const newOrderId = orderResponse.order?.id || orderResponse.id;
+      setOrderId(newOrderId);
 
-      setOrderId(order.id);
+      const amountForIntent = isTrialProduct ? 0 : Number(productPrice || 0);
 
-      if (paymentMethod === 'stripe') {
-        // amount a Stripe: 0 si trial, precio normal si no
-        const paymentData = await api.createPaymentIntent(order.id, totalNow, token);
+      const paymentIntentResponse = await api.createPaymentIntent(newOrderId, amountForIntent, token);
+      console.log('✅ Payment/Setup Intent creado:', paymentIntentResponse);
 
-        // CASO 1: Trial
-        if (isTrialProduct || paymentData.free_trial) {
-          setIsFreeTrial(true);
-          setFutureCharge(FUTURE_CHARGE_EUR);
-
-          if (paymentData.client_secret) {
-            setClientSecret(paymentData.client_secret);
-            setStep('payment');
-          } else {
-            // Fallback sin método guardado (backend ya pone la orden en processing)
-            clearSelectedProduct();
-            navigate(`/order-confirmation/${order.id}?trial=true`);
-          }
-        }
-        // CASO 2: Pago normal
-        else if (paymentData.client_secret) {
-          setIsFreeTrial(false);
-          setClientSecret(paymentData.client_secret);
-          setStep('payment');
-        } else {
-          throw new Error('Respuesta inválida del servidor');
-        }
-      } else {
-        // PayPal
+      if (paymentIntentResponse.client_secret) {
+        setClientSecret(paymentIntentResponse.client_secret);
         setStep('payment');
+      } else {
+        throw new Error('No se recibió client_secret desde el backend');
       }
     } catch (err) {
-      setError(err.message || 'Error al procesar la orden');
+      console.error('❌ Error creando orden:', err);
+      setError(err.message || 'Error al crear el pedido');
     } finally {
       setIsLoading(false);
     }
   };
 
+  const handlePaymentSuccess = async (result) => {
+    console.log('[Checkout] handlePaymentSuccess invocado con:', result);
+    setIsLoading(true);
+    setError(null);
 
-const handlePaymentSuccess = async (paymentDetails) => {
-  try {
-    const { token } = getToken();
+    try {
+      const { token } = getToken();
+      if (!token) throw new Error('No hay token de autenticación');
 
-    // Tipo de flujo
-    const isSetup = paymentDetails?.type === 'setup_intent' || isFreeTrial || totalNow === 0;
-    const isStripePI =
-      (paymentDetails?.id && paymentDetails.id.startsWith('pi_')) ||
-      paymentDetails?.object === 'payment_intent';
-    const isStripeSI =
-      (paymentDetails?.id && paymentDetails.id.startsWith('seti_')) ||
-      paymentDetails?.type === 'setup_intent';
+      console.log('[Checkout] Llamando confirmPayment con:', {
+        orderId,
+        intentId: result.id,
+        type: result.type,
+        status: result.status
+      });
 
-    // Plan A: confirmar en backend (Stripe)
-    if (isStripeSI || isStripePI) {
-      try {
-        await api.confirmPayment(
-          orderId,
-          isStripePI ? paymentDetails.id : null,  // payment_intent_id si aplica
-          token,
-          isStripeSI ? paymentDetails.id : null   // setup_intent_id si aplica
-        );
-      } catch (confirmError) {
-        // No rompemos el flujo; continuamos con verify-intent si es PI
-        console.warn('[Checkout] confirm-payment falló, seguimos con verify-intent si es PI:', confirmError);
+      const confirmData = await api.confirmPayment(
+        orderId,
+        result.type === 'setup_intent' ? null : result.id,
+        token,
+        result.type === 'setup_intent' ? result.id : null
+      );
+
+      console.log('[Checkout] confirmPayment devolvió:', confirmData);
+
+      if (confirmData.success) {
+        clearSelectedProduct();
+        const queryParam = isTrialProduct ? '?trial=true' : '';
+        console.log('[Checkout] Redirigiendo a confirmación:', `/order-confirmation/${orderId}${queryParam}`);
+        navigate(`/order-confirmation/${orderId}${queryParam}`);
+      } else {
+        throw new Error(confirmData.message || 'No se pudo confirmar el pago');
       }
-    }
-
-    // Plan B: verificar directamente el PaymentIntent en Stripe
-    if (isStripePI) {
+    } catch (err) {
+      console.error('[Checkout] Error en handlePaymentSuccess:', err);
+      setError(err.message || 'Error al confirmar el pago');
+      
       try {
-        await api.verifyIntent(orderId, paymentDetails.id, token);
+        const { token } = getToken();
+        await api.verifyIntent(orderId, result.id, token);
+        clearSelectedProduct();
+        navigate(`/order-confirmation/${orderId}`);
       } catch (verifyErr) {
-        console.warn('[Checkout] verify-intent no pudo confirmar el pedido:', verifyErr);
+        console.error('[Checkout] Error verificando intent:', verifyErr);
       }
+    } finally {
+      setIsLoading(false);
     }
-
-    // Pasarelas externas (PayPal, etc.)
-    if (!isStripePI && !isStripeSI) {
-      const txId =
-        paymentDetails?.id ||
-        paymentDetails?.purchase_units?.[0]?.payments?.captures?.[0]?.id ||
-        paymentDetails?.purchase_units?.[0]?.payments?.authorizations?.[0]?.id ||
-        'external';
-
-      try {
-        await api.updateOrder(
-          orderId,
-          {
-            status: 'processing',
-            transaction_id: txId,
-            add_note: 'Pago aprobado por pasarela externa',
-          },
-          token
-        );
-      } catch (e) {
-        console.warn('[Checkout] updateOrder (pasarela externa) avisó:', e);
-      }
-    }
-
-    clearSelectedProduct();
-    navigate(isSetup ? `/order-confirmation/${orderId}?trial=true` : `/order-confirmation/${orderId}`);
-  } catch (err) {
-    console.error('[Checkout] Error final en handlePaymentSuccess:', err);
-    clearSelectedProduct();
-    navigate(`/order-confirmation/${orderId}`);
-  }
-};
-
-
+  };
 
   const handlePaymentError = (errorMessage) => {
     setError(errorMessage);
   };
 
+  if (!selectedProduct) {
+    return null; // El useEffect ya redirige
+  }
+
   return (
-    <>
-      <Menu />
-      <div className="checkout-page mt-4">
-        <div className="checkout-container">
-          <h1 className="checkout-title">Finalizar compra</h1>
+    // 🔥 NUEVO: Envolver todo con CheckoutAuthGuard
+    <CheckoutAuthGuard>
+      <>
+        <Menu />
+        <div className="checkout-page mt-4">
+          <div className="checkout-container">
+            <h1 className="checkout-title">Finalizar compra</h1>
 
-          <div className="checkout-grid">
-            <div className="checkout-main">
-              {step === 'billing' && (
-                <div className="checkout-section">
-                  <h2>Datos de facturación</h2>
+            <div className="checkout-grid">
+              <div className="checkout-main">
+                {step === 'billing' && (
+                  <div className="checkout-section">
+                    <h2>Datos de facturación</h2>
 
-                  <div className="form-grid">
-                    <div className="form-field">
-                      <label>Nombre *</label>
-                      <input
-                        type="text"
-                        value={billingData.first_name}
-                        onChange={(e) => updateField('first_name', e.target.value)}
-                        placeholder="Tu nombre"
-                      />
-                    </div>
-
-                    <div className="form-field">
-                      <label>Apellidos *</label>
-                      <input
-                        type="text"
-                        value={billingData.last_name}
-                        onChange={(e) => updateField('last_name', e.target.value)}
-                        placeholder="Tus apellidos"
-                      />
-                    </div>
-
-                    <div className="form-field full-width">
-                      <label>Email *</label>
-                      <input
-                        type="email"
-                        value={billingData.email}
-                        onChange={(e) => updateField('email', e.target.value)}
-                        placeholder="tu@email.com"
-                      />
-                    </div>
-
-                    <div className="form-field full-width">
-                      <label>Teléfono</label>
-                      <input
-                        type="tel"
-                        value={billingData.phone}
-                        onChange={(e) => updateField('phone', e.target.value)}
-                        placeholder="+34 600 000 000"
-                      />
-                    </div>
-
-                    <div className="form-field full-width">
-                      <label>Dirección *</label>
-                      <input
-                        type="text"
-                        value={billingData.address_1}
-                        onChange={(e) => updateField('address_1', e.target.value)}
-                        placeholder="Calle, número, piso..."
-                      />
-                    </div>
-
-                    <div className="form-field">
-                      <label>Ciudad *</label>
-                      <input
-                        type="text"
-                        value={billingData.city}
-                        onChange={(e) => updateField('city', e.target.value)}
-                        placeholder="Tu ciudad"
-                      />
-                    </div>
-
-                    <div className="form-field">
-                      <label>Código postal *</label>
-                      <input
-                        type="text"
-                        value={billingData.postcode}
-                        onChange={(e) => updateField('postcode', e.target.value)}
-                        placeholder="28000"
-                      />
-                    </div>
-                  </div>
-
-                  <div className="payment-method-section">
-                    <h3>Método de pago</h3>
-                    <div className="payment-methods">
-                      <label className="payment-option">
+                    <div className="form-grid">
+                      <div className="form-field">
+                        <label>Nombre *</label>
                         <input
-                          type="radio"
-                          name="payment"
-                          value="stripe"
-                          checked={paymentMethod === 'stripe'}
-                          onChange={(e) => setPaymentMethod(e.target.value)}
+                          type="text"
+                          value={billingData.first_name}
+                          onChange={(e) => updateField('first_name', e.target.value)}
+                          placeholder="Tu nombre"
                         />
-                        <span>Tarjeta de crédito / Klarna</span>
-                      </label>
+                      </div>
 
-                      <label className="payment-option">
+                      <div className="form-field">
+                        <label>Apellidos *</label>
                         <input
-                          type="radio"
-                          name="payment"
-                          value="paypal"
-                          checked={paymentMethod === 'paypal'}
-                          onChange={(e) => setPaymentMethod(e.target.value)}
-                          disabled={isTrialProduct} // En trial, forzamos Stripe (para guardar método)
+                          type="text"
+                          value={billingData.last_name}
+                          onChange={(e) => updateField('last_name', e.target.value)}
+                          placeholder="Tus apellidos"
                         />
-                        <span>PayPal</span>
-                      </label>
+                      </div>
+
+                      <div className="form-field full-width">
+                        <label>Email *</label>
+                        <input
+                          type="email"
+                          value={billingData.email}
+                          onChange={(e) => updateField('email', e.target.value)}
+                          placeholder="tu@email.com"
+                        />
+                      </div>
+
+                      <div className="form-field full-width">
+                        <label>Teléfono</label>
+                        <input
+                          type="tel"
+                          value={billingData.phone}
+                          onChange={(e) => updateField('phone', e.target.value)}
+                          placeholder="+34 600 000 000"
+                        />
+                      </div>
+
+                      <div className="form-field full-width">
+                        <label>Dirección *</label>
+                        <input
+                          type="text"
+                          value={billingData.address_1}
+                          onChange={(e) => updateField('address_1', e.target.value)}
+                          placeholder="Calle, número, piso..."
+                        />
+                      </div>
+
+                      <div className="form-field">
+                        <label>Ciudad *</label>
+                        <input
+                          type="text"
+                          value={billingData.city}
+                          onChange={(e) => updateField('city', e.target.value)}
+                          placeholder="Tu ciudad"
+                        />
+                      </div>
+
+                      <div className="form-field">
+                        <label>Código postal *</label>
+                        <input
+                          type="text"
+                          value={billingData.postcode}
+                          onChange={(e) => updateField('postcode', e.target.value)}
+                          placeholder="28000"
+                        />
+                      </div>
                     </div>
+
+                    <div className="payment-method-section">
+                      <h3>Método de pago</h3>
+                      <div className="payment-methods">
+                        <label className="payment-option">
+                          <input
+                            type="radio"
+                            name="payment"
+                            value="stripe"
+                            checked={paymentMethod === 'stripe'}
+                            onChange={(e) => setPaymentMethod(e.target.value)}
+                          />
+                          <span>Tarjeta de crédito / Klarna</span>
+                        </label>
+
+                        <label className="payment-option">
+                          <input
+                            type="radio"
+                            name="payment"
+                            value="paypal"
+                            checked={paymentMethod === 'paypal'}
+                            onChange={(e) => setPaymentMethod(e.target.value)}
+                            disabled={isTrialProduct} // En trial, forzamos Stripe (para guardar método)
+                          />
+                          <span>PayPal</span>
+                        </label>
+                      </div>
+                    </div>
+
+                    {error && <div className="error-message">{error}</div>}
+
+                    <button onClick={createOrder} disabled={!isFormValid() || isLoading} className="btn-continue">
+                      {isLoading ? 'Creando orden...' : 'Continuar al pago'}
+                    </button>
                   </div>
+                )}
 
-                  {error && <div className="error-message">{error}</div>}
+                {step === 'payment' && paymentMethod === 'stripe' && clientSecret && (
+                  <div className="checkout-section">
+                    <h2>{totalNow === 0 ? 'Guardar método de pago' : 'Completar pago'}</h2>
 
-                  <button onClick={createOrder} disabled={!isFormValid() || isLoading} className="btn-continue">
-                    {isLoading ? 'Creando orden...' : 'Continuar al pago'}
-                  </button>
-                </div>
-              )}
+                    {error && <div className="error-message">{error}</div>}
 
-              {step === 'payment' && paymentMethod === 'stripe' && clientSecret && (
-                <div className="checkout-section">
-                  <h2>{totalNow === 0 ? 'Guardar método de pago' : 'Completar pago'}</h2>
+                    <Elements stripe={stripePromise} options={{ clientSecret }}>
+                      <StripePaymentForm
+                        orderId={orderId}
+                        amount={totalNow}
+                        onSuccess={handlePaymentSuccess}
+                        onError={handlePaymentError}
+                        isSetupIntent={totalNow === 0}
+                      />
+                    </Elements>
+                  </div>
+                )}
 
-                  {error && <div className="error-message">{error}</div>}
-
-                  <Elements stripe={stripePromise} options={{ clientSecret }}>
-                    <StripePaymentForm
-                      orderId={orderId}
-                      amount={totalNow}
-                      onSuccess={handlePaymentSuccess}
-                      onError={handlePaymentError}
-                      isSetupIntent={totalNow === 0}
-                    />
-                  </Elements>
-                </div>
-              )}
-
-              {step === 'payment' && paymentMethod === 'paypal' && (
-                <div className="checkout-section">
-                  <h2>Pagar con PayPal</h2>
-                  {error && <div className="error-message">{error}</div>}
-                  <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID, currency: 'EUR' }}>
-                    <PayPalButtons
-                      createOrder={(data, actions) => {
-                        return actions.order.create({
-                          purchase_units: [
-                            {
-                              reference_id: orderId.toString(),
-                              amount: {
-                                value: Number(totalNow).toFixed(2),
-                                currency_code: 'EUR',
+                {step === 'payment' && paymentMethod === 'paypal' && (
+                  <div className="checkout-section">
+                    <h2>Pagar con PayPal</h2>
+                    {error && <div className="error-message">{error}</div>}
+                    <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID, currency: 'EUR' }}>
+                      <PayPalButtons
+                        createOrder={(data, actions) => {
+                          return actions.order.create({
+                            purchase_units: [
+                              {
+                                reference_id: orderId.toString(),
+                                amount: {
+                                  value: Number(totalNow).toFixed(2),
+                                  currency_code: 'EUR',
+                                },
                               },
-                            },
-                          ],
-                        });
-                      }}
-                      onApprove={async (data, actions) => {
-                        const details = await actions.order.capture();
-                        handlePaymentSuccess(details);
-                      }}
-                      onError={() => handlePaymentError('Error con PayPal')}
-                    />
-                  </PayPalScriptProvider>
-                </div>
-              )}
-            </div>
-
-            <div className="checkout-sidebar">
-              <div className="order-summary">
-                <h3>Resumen del pedido</h3>
-
-                <div className="product-summary">
-                  <div className="product-name">{selectedProduct.name}</div>
-                  <div className="product-price">
-                    {isTrialProduct ? (
-                      <>
-                        <span className="trial-badge">Prueba gratuita</span>
-                        <span className="future-price">
-                        {(futureCharge ?? FUTURE_CHARGE_EUR).toFixed(2)}€ después de 14 días
-                        </span>
-                      </>
-                    ) : (
-                      `${Number(selectedProduct.price || 0).toFixed(2)}€`
-                    )}
+                            ],
+                          });
+                        }}
+                        onApprove={async (data, actions) => {
+                          const details = await actions.order.capture();
+                          handlePaymentSuccess(details);
+                        }}
+                        onError={() => handlePaymentError('Error con PayPal')}
+                      />
+                    </PayPalScriptProvider>
                   </div>
-                </div>
+                )}
+              </div>
 
-                <div className="summary-total">
-                  <span>Total {totalNow === 0 ? 'hoy' : ''}:</span>
-                  <span>{totalNow === 0 ? '0€' : `${Number(totalNow).toFixed(2)}€`}</span>
-                </div>
+              <div className="checkout-sidebar">
+                <div className="order-summary">
+                  <h3>Resumen del pedido</h3>
 
-                <div className="summary-benefits">
-                  <div>{totalNow === 0 ? '14 días de prueba gratuita' : 'Entrega inmediata'}</div>
-                  <div>Pago 100% seguro</div>
-                  <div>Soporte incluido</div>
-                  {totalNow === 0 && <div>Cancela cuando quieras</div>}
+                  <div className="product-summary">
+                    <div className="product-name">{selectedProduct.name}</div>
+                    <div className="product-price">
+                      {isTrialProduct ? (
+                        <>
+                          <span className="trial-badge">Prueba gratuita</span>
+                          <span className="future-price">
+                          {(futureCharge ?? FUTURE_CHARGE_EUR).toFixed(2)}€ después de 14 días
+                          </span>
+                        </>
+                      ) : (
+                        `${Number(selectedProduct.price || 0).toFixed(2)}€`
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="summary-total">
+                    <span>Total {totalNow === 0 ? 'hoy' : ''}:</span>
+                    <span>{totalNow === 0 ? '0€' : `${Number(totalNow).toFixed(2)}€`}</span>
+                  </div>
+
+                  <div className="summary-benefits">
+                    <div>{totalNow === 0 ? '14 días de prueba gratuita' : 'Entrega inmediata'}</div>
+                    <div>Pago 100% seguro</div>
+                    <div>Soporte incluido</div>
+                    {totalNow === 0 && <div>Cancela cuando quieras</div>}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      </div> 
-    </>
+        </div> 
+      </>
+    </CheckoutAuthGuard>
   );
 };
 
 export default CheckoutPage;
-
-
-
 
 
 


### PR DESCRIPTION
FEATURE: añadir autenticación en checkout con modal integrado

- Implementa CheckoutAuthGuard que envuelve el checkout y valida autenticación
- Muestra AuthModal existente cuando usuario no está logueado al comprar
- Guarda intención de checkout en sessionStorage para restaurar después del login
- Añade funciones saveCheckoutIntent, restoreCheckoutIntent y clearCheckoutIntent en AuthContext
- Restaura automáticamente producto seleccionado tras login/registro exitoso
- Difumina checkout de fondo mientras se muestra modal de autenticación
- Permite cerrar modal con X, ESC o click fuera (redirige a home si no se autentica)
- Añade enlace 'Regístrate aquí' en modal de login para cambiar a signup
- Corrige tipo de modal de 'register' a 'signup' para compatibilidad
- Modal se cierra automáticamente tras autenticación exitosa
- Usuario permanece en checkout después de login/registro para completar compra
- Expira intención de checkout tras 30 minutos de inactividad